### PR TITLE
chore(flake): remove devshell/flake-utils input...

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
     };
     gomod2nix = {
       url = "github:nix-community/gomod2nix";


### PR DESCRIPTION
it's gone as of https://github.com/numtide/devshell/pull/324 (and not in the lock file anymore)