### PR TITLE
replace devshell with mkShell

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,26 +1,22 @@
 {
-  pkgs,
   perSystem,
+  pkgs,
   ...
 }:
-pkgs.mkShell {
-  GOROOT = "${pkgs.go}/share/go";
-
-  packages = with pkgs; [
-    go
-    gotools
-    enumer
-    delve
-    pprof
-    graphviz
-    libusb1.dev
-    gcc
-    pkg-config
-    util-linux.dev
-    pciutils
-    hwinfo
-    perSystem.gomod2nix.default
-    golangci-lint
-    cobra-cli
-  ];
-}
+perSystem.self.nixos-facter.overrideAttrs (old: {
+  GOROOT = "${old.go}/share/go";
+  nativeBuildInputs =
+    old.nativeBuildInputs
+    ++ [
+      perSystem.gomod2nix.default
+      pkgs.enumer
+      pkgs.delve
+      pkgs.pprof
+      pkgs.golangci-lint
+      pkgs.cobra-cli
+    ];
+  shellHook = ''
+    # this is only needed for hermetic builds
+    unset GO_NO_VENDOR_CHECKS GOSUMDB GOPROXY GOFLAGS
+  '';
+})


### PR DESCRIPTION
devshell doesn't work with nixpkgs's C infrastructure as it doesn't provide the right environment variables like
NIX_CFLAGS_COMPILE/NIX_LDFLAGS. This is a long-standing issue. Also export LD_LIBRARY_PATH is not a good idea as it will crash other applications that are not part of the devshell i.e. editors.