### PR TITLE
feat: use a fork of hwinfo

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -14,6 +14,7 @@ perSystem.self.nixos-facter.overrideAttrs (old: {
       pkgs.pprof
       pkgs.golangci-lint
       pkgs.cobra-cli
+      perSystem.self.hwinfo
     ];
   shellHook = ''
     # this is only needed for hermetic builds

--- a/nix/packages/hwinfo.nix
+++ b/nix/packages/hwinfo.nix
@@ -1,11 +1,11 @@
 {pkgs, ...}:
 # we use this fork for updated pci and usb id resolution until https://github.com/openSUSE/hwinfo/pull/144 is
 # merged upstream
-pkgs.hwinfo.overrideAttrs (_old: {
+pkgs.hwinfo.overrideAttrs {
   src = pkgs.fetchFromGitHub {
     owner = "brianmcgee";
     repo = "hwinfo";
     rev = "6fa35c4e8404217a6dc57cff1f5639f7b596be18";
     hash = "sha256-HYLoTArnwZsIVzNFtPeJus9inDKx3kYJSKWIu5IPp14=";
   };
-})
+}

--- a/nix/packages/hwinfo.nix
+++ b/nix/packages/hwinfo.nix
@@ -1,0 +1,11 @@
+{pkgs, ...}:
+# we use this fork for updated pci and usb id resolution until https://github.com/openSUSE/hwinfo/pull/144 is
+# merged upstream
+pkgs.hwinfo.overrideAttrs (_old: {
+  src = pkgs.fetchFromGitHub {
+    owner = "brianmcgee";
+    repo = "hwinfo";
+    rev = "6fa35c4e8404217a6dc57cff1f5639f7b596be18";
+    hash = "sha256-HYLoTArnwZsIVzNFtPeJus9inDKx3kYJSKWIu5IPp14=";
+  };
+})

--- a/nix/packages/nixos-facter/default.nix
+++ b/nix/packages/nixos-facter/default.nix
@@ -34,7 +34,7 @@ in
 
     buildInputs = [
       pkgs.libusb1
-      pkgs.hwinfo
+      perSystem.self.hwinfo
     ];
 
     nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
Upstream, the pci and usb ids were last imported in 2021.

Switching to this fork is a short-term fix until its changes have been merged upstream https://github.com/openSUSE/hwinfo/pull/144.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
