### PR TITLE
fix: lookup of pci and usb ids when specifying hardware features

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/numtide/nixos-facter/pkg/hwinfo"
@@ -91,6 +92,17 @@ func init() {
 		"sysfs", "udev", "block", "wlan",
 	}
 
+	// we strip default and int from the feature list
+	allFeatures := hwinfo.ProbeFeatureStrings()
+	slices.DeleteFunc(allFeatures, func(str string) bool {
+		switch str {
+		case "default", "int":
+			return true
+		default:
+			return false
+		}
+	})
+
 	f.StringSliceVarP(
 		&hardwareFeatures,
 		"hardware-features",
@@ -98,8 +110,7 @@ func init() {
 		defaultFeatures,
 		fmt.Sprintf(
 			"Hardware features to probe. Possible values are %s",
-			// we strip default from the feature list
-			strings.Replace(strings.Join(hwinfo.ProbeFeatureStrings(), ","), "default,", "", 1),
+			strings.Join(allFeatures, ","),
 		),
 	)
 }

--- a/pkg/hwinfo/hwinfo.go
+++ b/pkg/hwinfo/hwinfo.go
@@ -31,6 +31,10 @@ func Scan(probes []ProbeFeature) ([]Smbios, []*HardwareItem, error) {
 	// initialise the struct to hold scan data
 	data := (*C.hd_data_t)(unsafe.Pointer(C.calloc(1, C.size_t(unsafe.Sizeof(C.hd_data_t{})))))
 
+	// ProbeFeatureInt needs to always be set, otherwise we don't get pci and usb vendor id lookups.
+	// https://github.com/openSUSE/hwinfo/blob/c87f449f1d4882c71b0a1e6dc80638224a5baeed/src/hd/hd.c#L597-L605
+	C.hd_set_probe_feature(data, C.enum_probe_feature(ProbeFeatureInt))
+
 	// set the hardware probes to run
 	for _, probe := range probes {
 		C.hd_set_probe_feature(data, C.enum_probe_feature(probe))


### PR DESCRIPTION
We were losing pci and usb lookups when using anything other than `all` for `hardware-features`.

This fixes that by mixing in the `int` probe feature regardless of the list provided, matching this behaviour https://github.com/openSUSE/hwinfo/blob/c87f449f1d4882c71b0a1e6dc80638224a5baeed/src/hd/hd.c#L597-L605

Closes #62 