### PR TITLE
edid data is already being decoded

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
-if ! has nix_direnv_version || ! nix_direnv_version 2.4.0; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.4.0/direnvrc" "sha256-XQzUAvL6pysIJnRJyR7uVpmUSZfc7LSgWQwq/4mBr1U="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
 fi
 
 watch_file flake.nix

--- a/pkg/hwinfo/detail_pci.go
+++ b/pkg/hwinfo/detail_pci.go
@@ -75,10 +75,6 @@ type DetailPci struct {
 	SysfsBusId  string `json:"-"`                      // sysfs bus id
 	ModuleAlias string `json:"module_alias,omitempty"` // module alias
 	Label       string `json:"label,omitempty"`        // Consistent Device Name (CDN), pci firmware 3.1, chapter 4.6.7
-
-	// todo edid data
-	// EdidData   [6][0x80]byte `json:",omitempty"` // edid record
-	// EdidLength [6]uint       `json:",omitempty"` // edid record length
 }
 
 func (p DetailPci) DetailType() DetailType {
@@ -119,6 +115,5 @@ func NewDetailPci(pci C.hd_detail_pci_t) (Detail, error) {
 		SysfsBusId:     C.GoString(data.sysfs_bus_id),
 		ModuleAlias:    C.GoString(data.modalias),
 		Label:          C.GoString(data.label),
-		// todo edid data
 	}, nil
 }


### PR DESCRIPTION
EDID data is already being decoded in the following models:

- https://github.com/numtide/nixos-facter/blob/main/pkg/hwinfo/detail_monitor.go
- https://github.com/numtide/nixos-facter/blob/main/pkg/hwinfo/resource_monitor.go

Closes #55 