### PR TITLE
fix/aarch64 segfault

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,13 +93,13 @@ func init() {
 	// These will be added on a priority / need basis.
 
 	defaultFeatures := []string{
-		"memory", "pci", "net", "serial", "cpu", "bios", "monitor", "mouse", "scsi", "usb", "prom", "sbus", "sys",
-		"sysfs", "udev", "block", "wlan",
+		"memory", "pci", "net", "serial", "cpu", "bios", "monitor", "scsi", "usb", "prom", "sbus", "sys", "sysfs",
+		"udev", "block", "wlan",
 	}
 
 	// we strip default and int from the feature list
-	allFeatures := hwinfo.ProbeFeatureStrings()
-	slices.DeleteFunc(allFeatures, func(str string) bool {
+	probeFeatures := hwinfo.ProbeFeatureStrings()
+	slices.DeleteFunc(probeFeatures, func(str string) bool {
 		switch str {
 		case "default", "int":
 			return true
@@ -115,7 +115,7 @@ func init() {
 		defaultFeatures,
 		fmt.Sprintf(
 			"Hardware items to probe. Possible values are %s",
-			strings.Join(allFeatures, ","),
+			strings.Join(probeFeatures, ","),
 		),
 	)
 }

--- a/pkg/facter/report.go
+++ b/pkg/facter/report.go
@@ -11,11 +11,11 @@ import (
 )
 
 type Report struct {
-	Hardware       []*hwinfo.HardwareItem `json:"hardware"`
-	Smbios         []hwinfo.Smbios        `json:"smbios,omitempty"`
-	Swap           []*ephem.SwapEntry     `json:"swap,omitempty"`
-	System         string                 `json:"system"`
-	Virtualisation virt.Type              `json:"virtualisation"`
+	Hardware       []*hwinfo.HardwareDevice `json:"hardware"`
+	Smbios         []hwinfo.Smbios          `json:"smbios,omitempty"`
+	Swap           []*ephem.SwapEntry       `json:"swap,omitempty"`
+	System         string                   `json:"system"`
+	Virtualisation virt.Type                `json:"virtualisation"`
 }
 
 type Scanner struct {

--- a/pkg/hwinfo/hwinfo.go
+++ b/pkg/hwinfo/hwinfo.go
@@ -15,7 +15,7 @@ import (
 	"unsafe"
 )
 
-func excludeDevice(item *HardwareItem) bool {
+func excludeDevice(item *HardwareDevice) bool {
 	if item.HardwareClass == HardwareClassNetworkInterface {
 		for _, driver := range item.Drivers {
 			// devices that are not mapped to hardware should be not included in the hardware report
@@ -27,7 +27,7 @@ func excludeDevice(item *HardwareItem) bool {
 	return false
 }
 
-func Scan(probes []ProbeFeature) ([]Smbios, []*HardwareItem, error) {
+func Scan(probes []ProbeFeature) ([]Smbios, []*HardwareDevice, error) {
 	// initialise the struct to hold scan data
 	data := (*C.hd_data_t)(unsafe.Pointer(C.calloc(1, C.size_t(unsafe.Sizeof(C.hd_data_t{})))))
 
@@ -53,9 +53,9 @@ func Scan(probes []ProbeFeature) ([]Smbios, []*HardwareItem, error) {
 		smbiosItems = append(smbiosItems, item)
 	}
 
-	var hardwareItems []*HardwareItem
+	var hardwareItems []*HardwareDevice
 	for hd := data.hd; hd != nil; hd = hd.next {
-		if item, err := NewHardwareItem(hd); err != nil {
+		if item, err := NewHardwareDevice(hd); err != nil {
 			return nil, nil, err
 		} else {
 			if excludeDevice(item) {
@@ -66,7 +66,7 @@ func Scan(probes []ProbeFeature) ([]Smbios, []*HardwareItem, error) {
 	}
 
 	// canonically sort by device index
-	slices.SortFunc(hardwareItems, func(a, b *HardwareItem) int {
+	slices.SortFunc(hardwareItems, func(a, b *HardwareDevice) int {
 		return int(a.Index) - int(b.Index)
 	})
 

--- a/pkg/hwinfo/report.go
+++ b/pkg/hwinfo/report.go
@@ -230,7 +230,7 @@ func NewDeviceNumber(num C.hd_dev_num_t) *DeviceNumber {
 	return &result
 }
 
-type HardwareItem struct {
+type HardwareDevice struct {
 	// Index is a unique index, starting at 1
 	Index uint `json:"index"`
 
@@ -297,7 +297,7 @@ type HardwareItem struct {
 	Label       string `json:"label,omitempty"`        // Consistent Device Name (CDN), pci firmware spec 3.1, chapter 4.6.7
 }
 
-func NewHardwareItem(hd *C.hd_t) (*HardwareItem, error) {
+func NewHardwareDevice(hd *C.hd_t) (*HardwareDevice, error) {
 	if hd == nil {
 		return nil, nil
 	}
@@ -322,7 +322,7 @@ func NewHardwareItem(hd *C.hd_t) (*HardwareItem, error) {
 		model = stripCpuFreq(model)
 	}
 
-	return &HardwareItem{
+	return &HardwareDevice{
 		Index:            uint(hd.idx),
 		Bus:              NewId(hd.bus),
 		Slot:             Slot(hd.slot),


### PR DESCRIPTION
I could identify that the `mouse` probe feature was causing the segfault on bld3.

A short-term fix is removing `mouse` from the default probe list. I've created #87 to follow up.

Closes #84 