### PR TITLE
fix: stripping cpu frequency from CPU model name

### DIFF
--- a/pkg/hwinfo/detail_cpu.go
+++ b/pkg/hwinfo/detail_cpu.go
@@ -47,7 +47,7 @@ type DetailCpu struct {
 	Bogo       float64  `json:"bogo"`
 }
 
-var matchCPUFreq = regexp.MustCompile(`, %d MHz$`)
+var matchCPUFreq = regexp.MustCompile(`, \d+ MHz$`)
 
 func stripCpuFreq(s string) string {
 	// strip frequency of the model name as it is not stable.


### PR DESCRIPTION
The regex was bad.

Signed-off-by: Brian McGee <brian@bmcgee.ie>
