### PR TITLE
feat/iommu

### DIFF
--- a/nix/packages/nixos-facter/gomod2nix.toml
+++ b/nix/packages/nixos-facter/gomod2nix.toml
@@ -13,96 +13,57 @@ schema = 3
   [mod."github.com/davecgh/go-spew"]
     version = "v1.1.2-0.20180830191138-d8f796af33cc"
     hash = "sha256-fV9oI51xjHdOmEx6+dlq7Ku2Ag+m/bmbzPo6A4Y74qc="
-  [mod."github.com/fsnotify/fsnotify"]
-    version = "v1.7.0"
-    hash = "sha256-MdT2rQyQHspPJcx6n9ozkLbsktIOJutOqDuKpNAtoZY="
   [mod."github.com/go-logfmt/logfmt"]
     version = "v0.6.0"
     hash = "sha256-RtIG2qARd5sT10WQ7F3LR8YJhS8exs+KiuUiVf75bWg="
-  [mod."github.com/hashicorp/hcl"]
-    version = "v1.0.0"
-    hash = "sha256-xsRCmYyBfglMxeWUvTZqkaRLSW+V2FvNodEDjTGg1WA="
   [mod."github.com/inconshreveable/mousetrap"]
     version = "v1.1.0"
     hash = "sha256-XWlYH0c8IcxAwQTnIi6WYqq44nOKUylSWxWO/vi+8pE="
   [mod."github.com/klauspost/cpuid/v2"]
     version = "v2.2.9-0.20240805145549-92d5326f011e"
     hash = "sha256-yCZS40L97G7WZHhy/A6I8ArEkyHi86DGAW43SziYPek="
+  [mod."github.com/kr/pretty"]
+    version = "v0.3.1"
+    hash = "sha256-DlER7XM+xiaLjvebcIPiB12oVNjyZHuJHoRGITzzpKU="
   [mod."github.com/lucasb-eyer/go-colorful"]
     version = "v1.2.0"
     hash = "sha256-Gg9dDJFCTaHrKHRR1SrJgZ8fWieJkybljybkI9x0gyE="
-  [mod."github.com/magiconair/properties"]
-    version = "v1.8.7"
-    hash = "sha256-XQ2bnc2s7/IH3WxEO4GishZurMyKwEclZy1DXg+2xXc="
   [mod."github.com/mattn/go-isatty"]
     version = "v0.0.18"
     hash = "sha256-QpIn0DSggtBn2ocyj0RlXDKLK5F5KZG1/ogzrqBCjF8="
   [mod."github.com/mattn/go-runewidth"]
     version = "v0.0.15"
     hash = "sha256-WP39EU2UrQbByYfnwrkBDoKN7xzXsBssDq3pNryBGm0="
-  [mod."github.com/mitchellh/mapstructure"]
-    version = "v1.5.0"
-    hash = "sha256-ztVhGQXs67MF8UadVvG72G3ly0ypQW0IRDdOOkjYwoE="
   [mod."github.com/muesli/reflow"]
     version = "v0.3.0"
     hash = "sha256-Pou2ybE9SFSZG6YfZLVV1Eyfm+X4FuVpDPLxhpn47Cc="
   [mod."github.com/muesli/termenv"]
     version = "v0.15.2"
     hash = "sha256-Eum/SpyytcNIchANPkG4bYGBgcezLgej7j/+6IhqoMU="
-  [mod."github.com/pelletier/go-toml/v2"]
-    version = "v2.2.2"
-    hash = "sha256-ukxk1Cfm6cQW18g/aa19tLcUu5BnF7VmfAvrDHAOl6A="
   [mod."github.com/pmezard/go-difflib"]
     version = "v1.0.1-0.20181226105442-5d4384ee4fb2"
     hash = "sha256-XA4Oj1gdmdV/F/+8kMI+DBxKPthZ768hbKsO3d9Gx90="
   [mod."github.com/rivo/uniseg"]
     version = "v0.4.7"
     hash = "sha256-rDcdNYH6ZD8KouyyiZCUEy8JrjOQoAkxHBhugrfHjFo="
-  [mod."github.com/sagikazarmark/locafero"]
-    version = "v0.4.0"
-    hash = "sha256-7I1Oatc7GAaHgAqBFO6Tv4IbzFiYeU9bJAfJhXuWaXk="
-  [mod."github.com/sagikazarmark/slog-shim"]
-    version = "v0.1.0"
-    hash = "sha256-F92BQXXmn3mCwu3mBaGh+joTRItQDSDhsjU6SofkYdA="
-  [mod."github.com/sourcegraph/conc"]
-    version = "v0.3.0"
-    hash = "sha256-mIdMs9MLAOBKf3/0quf1iI3v8uNWydy7ae5MFa+F2Ko="
-  [mod."github.com/spf13/afero"]
-    version = "v1.11.0"
-    hash = "sha256-+rV3cDZr13N8E0rJ7iHmwsKYKH+EhV+IXBut+JbBiIE="
-  [mod."github.com/spf13/cast"]
-    version = "v1.6.0"
-    hash = "sha256-hxioqRZfXE0AE5099wmn3YG0AZF8Wda2EB4c7zHF6zI="
   [mod."github.com/spf13/cobra"]
     version = "v1.8.1"
     hash = "sha256-yDF6yAHycV1IZOrt3/hofR+QINe+B2yqkcIaVov3Ky8="
   [mod."github.com/spf13/pflag"]
     version = "v1.0.5"
     hash = "sha256-w9LLYzxxP74WHT4ouBspH/iQZXjuAh2WQCHsuvyEjAw="
-  [mod."github.com/spf13/viper"]
-    version = "v1.19.0"
-    hash = "sha256-MZ8EAvdgpGbw6kmUz8UOaAAAMdPPGd14TrCBAY+A1T4="
   [mod."github.com/stretchr/testify"]
     version = "v1.9.0"
     hash = "sha256-uUp/On+1nK+lARkTVtb5RxlW15zxtw2kaAFuIASA+J0="
-  [mod."github.com/subosito/gotenv"]
-    version = "v1.6.0"
-    hash = "sha256-LspbjTniiq2xAICSXmgqP7carwlNaLqnCTQfw2pa80A="
-  [mod."go.uber.org/multierr"]
-    version = "v1.11.0"
-    hash = "sha256-Lb6rHHfR62Ozg2j2JZy3MKOMKdsfzd1IYTR57r3Mhp0="
   [mod."golang.org/x/exp"]
     version = "v0.0.0-20240506185415-9bf2ced13842"
     hash = "sha256-5JZE4OhePWHtObIT4RJOS+2zv265Io1yJkFeE8wHXY4="
   [mod."golang.org/x/sys"]
     version = "v0.22.0"
     hash = "sha256-RbG0XaXGGlErCsl2agvUxMnrkRwdbJLmriYT1H24FwA="
-  [mod."golang.org/x/text"]
-    version = "v0.15.0"
-    hash = "sha256-pBnj0AEkfkvZf+3bN7h6epCD2kurw59clDP7yWvxKlk="
-  [mod."gopkg.in/ini.v1"]
-    version = "v1.67.0"
-    hash = "sha256-V10ahGNGT+NLRdKUyRg1dos5RxLBXBk1xutcnquc/+4="
+  [mod."gopkg.in/check.v1"]
+    version = "v1.0.0-20190902080502-41f04d3bba15"
+    hash = "sha256-Xl5gjoqU26M+Yxm6Xok5VHVpYT5hItwsN7d2Wj9L020="
   [mod."gopkg.in/yaml.v3"]
     version = "v3.0.1"
     hash = "sha256-FqL9TKYJ0XkNwJFnq9j0VvJ5ZUU1RvH/52h/f5bkYAU="

--- a/pkg/facter/report.go
+++ b/pkg/facter/report.go
@@ -56,7 +56,14 @@ func (s *Scanner) Scan() (*Report, error) {
 	for idx := range devices {
 		// lookup iommu group before adding to the report
 		device := devices[idx]
-		device.IOMMUGroupId = iommuGroups[device.SysfsId]
+
+		var ok bool
+		device.SysfsIOMMUGroupId, ok = iommuGroups[device.SysfsId]
+		if !ok {
+			// indicates no group id found
+			device.SysfsIOMMUGroupId = -1
+		}
+
 		if err = report.Hardware.add(device); err != nil {
 			return nil, fmt.Errorf("failed to add to hardware report: %w", err)
 		}

--- a/pkg/facter/report.go
+++ b/pkg/facter/report.go
@@ -47,8 +47,17 @@ func (s *Scanner) Scan() (*Report, error) {
 		return nil, fmt.Errorf("failed to scan hardware: %w", err)
 	}
 
+	// read iommu groups
+	iommuGroups, err := hwinfo.IOMMUGroups()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read iommu groups: %w", err)
+	}
+
 	for idx := range devices {
-		if err = report.Hardware.add(devices[idx]); err != nil {
+		// lookup iommu group before adding to the report
+		device := devices[idx]
+		device.IOMMUGroupId = iommuGroups[device.SysfsId]
+		if err = report.Hardware.add(device); err != nil {
 			return nil, fmt.Errorf("failed to add to hardware report: %w", err)
 		}
 	}

--- a/pkg/hwinfo/iommu.go
+++ b/pkg/hwinfo/iommu.go
@@ -1,0 +1,47 @@
+package hwinfo
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	iommuSysfsPath = "/sys/kernel/iommu_groups"
+)
+
+func IOMMUGroups() (map[string]string, error) {
+	groups, err := os.ReadDir(iommuSysfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read iommu groups from sysfs: %w", err)
+	}
+
+	result := make(map[string]string)
+	for _, group := range groups {
+
+		if !group.IsDir() {
+			return nil, fmt.Errorf("non-directory entry found in %s: %s", iommuSysfsPath, group.Name())
+		}
+
+		groupPath := filepath.Join(iommuSysfsPath, group.Name())
+		devicesPath := filepath.Join(groupPath, "devices")
+
+		devices, err := os.ReadDir(devicesPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read devices from iommu group %s: %w", devicesPath, err)
+		}
+		for _, device := range devices {
+			devicePath := filepath.Join(devicesPath, device.Name())
+			resolvedPath, err := filepath.EvalSymlinks(devicePath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve device symlink '%s': %w", devicePath, err)
+			}
+
+			// sysfs id -> iommu group
+			// we trim leading '/sys'
+			result[resolvedPath[4:]] = groupPath[4:]
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/hwinfo/report.go
+++ b/pkg/hwinfo/report.go
@@ -386,8 +386,8 @@ type HardwareDevice struct {
 	AttachedTo        uint
 	SysfsId           string
 	SysfsBusId        string
+	SysfsIOMMUGroupId int
 	SysfsDeviceLink   string
-	IOMMUGroupId      string
 	UnixDeviceName    string
 	UnixDeviceNumber  *DeviceNumber
 	UnixDeviceNames   []string
@@ -441,7 +441,8 @@ func (h HardwareDevice) MarshalJSON() ([]byte, error) {
 		return json.Marshal(h.Detail)
 
 	default:
-		return json.Marshal(struct {
+
+		result := struct {
 			BusType           *Id           `json:"bus_type,omitempty"`
 			Slot              Slot          `json:"slot"`
 			BaseClass         *Id           `json:"base_class,omitempty"`
@@ -459,7 +460,7 @@ func (h HardwareDevice) MarshalJSON() ([]byte, error) {
 			SysfsId           string        `json:"sysfs_id,omitempty"`
 			SysfsBusId        string        `json:"sysfs_bus_id,omitempty"`
 			SysfsDeviceLink   string        `json:"sysfs_device_link,omitempty"`
-			IOMMUGroupId      string        `json:"iommu_group_id,omitempty"`
+			SysfsIOMMUGroupId uint          `json:"sysfs_iommu_group_id"`
 			UnixDeviceName    string        `json:"unix_device_name,omitempty"`
 			UnixDeviceNumber  *DeviceNumber `json:"unix_device_number,omitempty"`
 			UnixDeviceNames   []string      `json:"unix_device_names,omitempty"`
@@ -500,7 +501,6 @@ func (h HardwareDevice) MarshalJSON() ([]byte, error) {
 			SysfsId:           h.SysfsId,
 			SysfsBusId:        h.SysfsBusId,
 			SysfsDeviceLink:   h.SysfsDeviceLink,
-			IOMMUGroupId:      h.IOMMUGroupId,
 			UnixDeviceName:    h.UnixDeviceName,
 			UnixDeviceNumber:  h.UnixDeviceNumber,
 			UnixDeviceNames:   h.UnixDeviceNames,
@@ -523,7 +523,15 @@ func (h HardwareDevice) MarshalJSON() ([]byte, error) {
 			Requires:          h.Requires,
 			ModuleAlias:       h.ModuleAlias,
 			Label:             h.Label,
-		})
+		}
+
+		// -1 indicates no group was found
+		// We do this to overcome the fact that groups are 0 indexed and `json:"omitempty"` would not include group 0.
+		if h.SysfsIOMMUGroupId != -1 {
+			result.SysfsIOMMUGroupId = uint(h.SysfsIOMMUGroupId)
+		}
+
+		return json.Marshal(result)
 	}
 }
 

--- a/pkg/hwinfo/report.go
+++ b/pkg/hwinfo/report.go
@@ -368,33 +368,34 @@ type HardwareDevice struct {
 	Index uint `json:"-"`
 
 	// Bus type (id and name)
-	BusType           *Id           `json:"bus_type,omitempty"`
-	Slot              Slot          `json:"slot"`
-	BaseClass         *Id           `json:"base_class,omitempty"`
-	SubClass          *Id           `json:"sub_class,omitempty"`
-	PciInterface      *Id           `json:"pci_interface,omitempty"`
-	Vendor            *Id           `json:"vendor,omitempty"`
-	SubVendor         *Id           `json:"sub_vendor,omitempty"`
-	Device            *Id           `json:"device,omitempty"`
-	SubDevice         *Id           `json:"sub_device,omitempty"`
-	Revision          *Id           `json:"revision,omitempty"`
-	Serial            string        `json:"-"` // exclude from json output
-	CompatVendor      *Id           `json:"compat_vendor,omitempty"`
-	CompatDevice      *Id           `json:"compat_device,omitempty"`
-	HardwareClass     HardwareClass `json:"-"`
-	Model             string        `json:"model,omitempty"`
-	AttachedTo        uint          `json:"attached_to,omitempty"`
-	SysfsId           string        `json:"sysfs_id,omitempty"`
-	SysfsBusId        string        `json:"sysfs_bus_id,omitempty"`
-	SysfsDeviceLink   string        `json:"sysfs_device_link,omitempty"`
-	UnixDeviceName    string        `json:"unix_device_name,omitempty"`
-	UnixDeviceNumber  *DeviceNumber `json:"unix_device_number,omitempty"`
-	UnixDeviceNames   []string      `json:"unix_device_names,omitempty"`
-	UnixDeviceName2   string        `json:"unix_device_name_2,omitempty"`
-	UnixDeviceNumber2 *DeviceNumber `json:"unix_device_number_2,omitempty"`
-	RomId             string        `json:"rom_id,omitempty"`
-	Udi               string        `json:"udi,omitempty"`
-	ParentUdi         string        `json:"parent_udi,omitempty"`
+	BusType           *Id
+	Slot              Slot
+	BaseClass         *Id
+	SubClass          *Id
+	PciInterface      *Id
+	Vendor            *Id
+	SubVendor         *Id
+	Device            *Id
+	SubDevice         *Id
+	Revision          *Id
+	Serial            string
+	CompatVendor      *Id
+	CompatDevice      *Id
+	HardwareClass     HardwareClass
+	Model             string
+	AttachedTo        uint
+	SysfsId           string
+	SysfsBusId        string
+	SysfsDeviceLink   string
+	IOMMUGroupId      string
+	UnixDeviceName    string
+	UnixDeviceNumber  *DeviceNumber
+	UnixDeviceNames   []string
+	UnixDeviceName2   string
+	UnixDeviceNumber2 *DeviceNumber
+	RomId             string
+	Udi               string
+	ParentUdi         string
 
 	/*
 		UniqueId is a unique string identifying this hardware.
@@ -404,33 +405,35 @@ type HardwareDevice struct {
 		The string must not contain slashes ("/") because we're going to create files with this id as name.
 		Apart from this, there are no restrictions on the form of this string.
 	*/
-	UniqueId  string   `json:"-"`
-	UniqueIds []string `json:"-"`
+	UniqueId  string
+	UniqueIds []string
 
-	Resources []Resource `json:"resources,omitempty"`
-	Detail    Detail     `json:"detail,omitempty"`
+	Resources []Resource
+	Detail    Detail
 
-	Hotplug     Hotplug `json:"hotplug"`      // indicates what kind of hotplug device (if any) this is
-	HotplugSlot uint    `json:"hotplug_slot"` // slot the hotplug device is connected to (e.g. PCMCIA socket), count is 1-based (0: no info available)
+	Hotplug     Hotplug // indicates what kind of hotplug device (if any) this is
+	HotplugSlot uint    // slot the hotplug device is connected to (e.g. PCMCIA socket), count is 1-based (0: no info available)
 
 	Is Is `json:"is"` // high level device properties
 
-	Driver        string     `json:"driver,omitempty"`         // currently active driver
-	DriverModule  string     `json:"driver_module,omitempty"`  // currently active driver module (if any)
-	Drivers       []string   `json:"drivers,omitempty"`        // list of currently active drivers
-	DriverModules []string   `json:"driver_modules,omitempty"` // list of currently active driver modules
-	DriverInfo    DriverInfo `json:"driver_info,omitempty"`    // device driver info
-	UsbGuid       string     `json:"usb_guid,omitempty"`       // USB Global Unique Identifier.
-	Requires      []string   `json:",omitempty"`               // packages/programs required for this hardware
+	Driver        string     // currently active driver
+	DriverModule  string     // currently active driver module (if any)
+	Drivers       []string   // list of currently active drivers
+	DriverModules []string   // list of currently active driver modules
+	DriverInfo    DriverInfo // device driver info
+	UsbGuid       string     // USB Global Unique Identifier.
+	Requires      []string   // packages/programs required for this hardware
 
 	// todo hal_prop
 	// todo persistent_prop
 
-	ModuleAlias string `json:"module_alias,omitempty"` // module alias
-	Label       string `json:"label,omitempty"`        // Consistent Device Name (CDN), pci firmware spec 3.1, chapter 4.6.7
+	ModuleAlias string // module alias
+	Label       string // Consistent Device Name (CDN), pci firmware spec 3.1, chapter 4.6.7
 }
 
 func (h HardwareDevice) MarshalJSON() ([]byte, error) {
+	// TODO improve this pattern
+
 	switch h.BaseClass.Value {
 	case 257:
 		// internally used class for things such as cpu, memory and so on where most of the shared hardware device
@@ -456,6 +459,7 @@ func (h HardwareDevice) MarshalJSON() ([]byte, error) {
 			SysfsId           string        `json:"sysfs_id,omitempty"`
 			SysfsBusId        string        `json:"sysfs_bus_id,omitempty"`
 			SysfsDeviceLink   string        `json:"sysfs_device_link,omitempty"`
+			IOMMUGroupId      string        `json:"iommu_group_id,omitempty"`
 			UnixDeviceName    string        `json:"unix_device_name,omitempty"`
 			UnixDeviceNumber  *DeviceNumber `json:"unix_device_number,omitempty"`
 			UnixDeviceNames   []string      `json:"unix_device_names,omitempty"`
@@ -496,6 +500,7 @@ func (h HardwareDevice) MarshalJSON() ([]byte, error) {
 			SysfsId:           h.SysfsId,
 			SysfsBusId:        h.SysfsBusId,
 			SysfsDeviceLink:   h.SysfsDeviceLink,
+			IOMMUGroupId:      h.IOMMUGroupId,
 			UnixDeviceName:    h.UnixDeviceName,
 			UnixDeviceNumber:  h.UnixDeviceNumber,
 			UnixDeviceNames:   h.UnixDeviceNames,


### PR DESCRIPTION
It captures IOMMU groups in `sysfs_iommu_group_id`. 

```json
        "model": "AMD Starship/Matisse Reserved SPP",
        "attached_to": 69,
        "sysfs_id": "/devices/pci0000:00/0000:00:01.2/0000:02:00.0/0000:03:08.0/0000:08:00.0",
        "sysfs_bus_id": "0000:08:00.0",
        "sysfs_iommu_group_id": 20,
```

Closes #104 