### PR TITLE
fix: change language in smbios to an array

### DIFF
--- a/pkg/facter/smbios.go
+++ b/pkg/facter/smbios.go
@@ -31,7 +31,7 @@ type Smbios struct {
 	HardwareSecurity []hwinfo.Smbios `json:"hardware_security,omitempty"`
 
 	// Language contains language-related information, including supported and current languages.
-	Language *hwinfo.SmbiosLanguage `json:"language,omitempty"`
+	Language []hwinfo.Smbios `json:"language,omitempty"`
 
 	// Memory64Error provides information on 64-bit memory errors.
 	Memory64Error []hwinfo.Smbios `json:"memory_64_error,omitempty"`
@@ -114,13 +114,7 @@ func (s *Smbios) add(item hwinfo.Smbios) error {
 	case hwinfo.SmbiosTypeHardwareSecurity:
 		s.GroupAssociations = append(s.GroupAssociations, item)
 	case hwinfo.SmbiosTypeLanguage:
-		if s.Language != nil {
-			return fmt.Errorf("language field is already set")
-		} else if language, ok := item.(hwinfo.SmbiosLanguage); !ok {
-			return fmt.Errorf("expected hwinfo.SmbiosLanguage, found %T", item)
-		} else {
-			s.Language = &language
-		}
+		s.Language = append(s.Language, item)
 	case hwinfo.SmbiosTypeMemory64Error:
 		s.Memory64Error = append(s.Memory64Error, item)
 	case hwinfo.SmbiosTypeMemoryArray:


### PR DESCRIPTION
When running nixos-facter on a Topton 4-port x86_64 Celeron N5105, the SMBIOS is returning multiple language entries.

```console
sudo dmidecode -t bios
# dmidecode 3.6
Getting SMBIOS data from sysfs.
SMBIOS 3.3.0 present.

...

Handle 0x0017, DMI type 13, 22 bytes
BIOS Language Information
	Language Description Format: Long
	Installable Languages: 1
		en|US|iso8859-1
	Currently Installed Language: en|US|iso8859-1

Handle 0x005E, DMI type 13, 22 bytes
BIOS Language Information
	Language Description Format: Abbreviated
	Installable Languages: 1
		enUS
	Currently Installed Language: enUS
```

 Closes #125
