### PR TITLE
fix xen parsing

### DIFF
--- a/pkg/virt/detect_vm_xen.go
+++ b/pkg/virt/detect_vm_xen.go
@@ -40,7 +40,7 @@ func detectXenDom0() (bool, error) {
 		// read failure
 		return false, err
 	} else if len(b) > 0 {
-		features, err := strconv.ParseUint(string(b), 16, 64)
+		features, err := strconv.ParseUint(strings.TrimSpace(string(b)), 16, 64)
 		if err != nil {
 			return false, fmt.Errorf("failed to read %s: %w", featuresPath, err)
 		}


### PR DESCRIPTION
```
failed to scan: failed to detect virtualisation: failed to read /sys/hypervisor/properties/features: strconv.ParseUint: parsing "00002705\n": invalid syntax
```