### PR TITLE
fix: classification of pci and usb devices

### DIFF
--- a/docs/content/getting-started/generate-report.md
+++ b/docs/content/getting-started/generate-report.md
@@ -18,7 +18,6 @@ To generate a report, you will need to have [Nix] installed on the target machin
       github:numtide/nixos-facter -- -o facter.json
     ```
 
-
 This will scan your system and produce a JSON-based report in a file named `facter.json`:
 
 ```json title="facter.json"

--- a/pkg/ephem/swap_test.go
+++ b/pkg/ephem/swap_test.go
@@ -35,10 +35,10 @@ func TestReadSwapFile(t *testing.T) {
 	as.NoError(err)
 	as.Empty(swaps)
 
-	swaps, err = ReadSwapFile(strings.NewReader(corrupt))
+	_, err = ReadSwapFile(strings.NewReader(corrupt))
 	as.Errorf(err, "malformed entry in swaps file: '%s'", "foo bar baz")
 
-	swaps, err = ReadSwapFile(strings.NewReader(badPartition))
+	_, err = ReadSwapFile(strings.NewReader(badPartition))
 	as.Errorf(err, "malformed entry in swaps file: '%s'", `/var/lib/swap-1							foo        1048576	123		-3`)
 
 	swaps, err = ReadSwapFile(strings.NewReader(sample))

--- a/pkg/facter/hardware.go
+++ b/pkg/facter/hardware.go
@@ -185,7 +185,15 @@ func compareDevice(a hwinfo.HardwareDevice, b hwinfo.HardwareDevice) int {
 }
 
 func (h *Hardware) add(device hwinfo.HardwareDevice) error {
-	switch device.Class {
+	// start with the overall device class
+	class := device.Class
+
+	// attempt to fall back to the class list if it's unknown
+	if class == hwinfo.HardwareClassUnknown && len(device.ClassList) > 0 {
+		class = device.ClassList[0]
+	}
+
+	switch class {
 	case hwinfo.HardwareClassBios:
 		if h.Bios != nil {
 			return fmt.Errorf("bios field is already set")


### PR DESCRIPTION
Improves overall classification by capturing the class list of the underlying hardware item.

When the overall hardware class is unknown, we call back to the class list which typically identifies it as usb or pci etc.

Adds the `class` and `class_list` fields to the JSON output for clarity.

We should consider whether we allow the same hardware item in different sections of the hardware report based on the `class_list`.

Closes #136 
