### PR TITLE
feat: add a hex field to Id types

### DIFF
--- a/pkg/hwinfo/id.go
+++ b/pkg/hwinfo/id.go
@@ -68,18 +68,28 @@ type Id struct {
 	Name string
 }
 
+type idJson struct {
+	Hex   string `json:"hex,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Value uint16 `json:"value"`
+}
+
 func (i Id) MarshalJSON() ([]byte, error) {
 	switch i.Type {
+
 	case IdTagSpecial:
 		return json.Marshal(i.Name)
-	default:
-		return json.Marshal(struct {
-			Name  string `json:"name,omitempty"`
-			Value uint16 `json:"value"`
-		}{
+
+	case 0, IdTagPci, IdTagEisa, IdTagUsb, IdTagPcmcia, IdTagSdio:
+
+		return json.Marshal(idJson{
+			Hex:   fmt.Sprintf("%04x", i.Value),
 			Name:  i.Name,
 			Value: i.Value,
 		})
+
+	default:
+		return nil, fmt.Errorf("unknown id type %d", i.Type)
 	}
 }
 


### PR DESCRIPTION
Helps address issues brought up in https://github.com/numtide/nixos-facter-modules/pull/58 by introducing an additional hex field in the Id type.

Eventually, we can make this a breaking change by removing the value field and incrementing the report version.

This is a chance to test out how we can introduce breaking changes, whilst allowing module authors time to update.

Report output looks like this:

```json
        "base_class": {
          "hex": "0106",
          "name": "Mass Storage Device",
          "value": 262
        },
        "sub_class": {
          "hex": "0000",
          "name": "Disk",
          "value": 0
        },
        "vendor": {
          "hex": "15b7",
          "value": 5559
        },
        "sub_vendor": {
          "hex": "15b7",
          "value": 5559
        },
```

Closes #141
