### PR TITLE
devshell: remove pprof

### DIFF
--- a/nix/devshells/default.nix
+++ b/nix/devshells/default.nix
@@ -8,7 +8,6 @@ perSystem.self.nixos-facter.overrideAttrs (old: {
   nativeBuildInputs = old.nativeBuildInputs ++ [
     pkgs.enumer
     pkgs.delve
-    pkgs.pprof
     pkgs.gotools
     pkgs.golangci-lint
     pkgs.cobra-cli


### PR DESCRIPTION

it's not really used as we don't care too much about performance and
it's currently broken in nixpkgs
