### PR TITLE
drop unused godoc

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,64 +63,6 @@
         "type": "github"
       }
     },
-    "godoc": {
-      "inputs": {
-        "blueprint": [
-          "blueprint"
-        ],
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "gomod2nix": "gomod2nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "systems": [
-          "systems"
-        ],
-        "treefmt-nix": [
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1725981199,
-        "narHash": "sha256-QoXfZPi+k1dAh6p9uD8Ie64lECDm5XyoClmzhxWuDqs=",
-        "owner": "numtide",
-        "repo": "godoc",
-        "rev": "6657fc706efcd44a05bd7c80c20696c7513193c6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "godoc",
-        "type": "github"
-      }
-    },
-    "gomod2nix": {
-      "inputs": {
-        "flake-utils": [
-          "godoc",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "godoc",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1722589758,
-        "narHash": "sha256-sbbA8b6Q2vB/t/r1znHawoXLysCyD4L/6n6/RykiSnA=",
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "rev": "4e08ca09253ef996bd4c03afa383b23e35fe28a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
     "hwinfo": {
       "inputs": {
         "blueprint": [
@@ -169,7 +111,6 @@
         "blueprint": "blueprint",
         "disko": "disko",
         "flake-utils": "flake-utils",
-        "godoc": "godoc",
         "hwinfo": "hwinfo",
         "nixpkgs": "nixpkgs",
         "systems": "systems",

--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,6 @@
     hwinfo.inputs.nixpkgs.follows = "nixpkgs";
     hwinfo.inputs.systems.follows = "systems";
     hwinfo.inputs.blueprint.follows = "blueprint";
-
-    godoc.url = "github:numtide/godoc";
-    godoc.inputs.nixpkgs.follows = "nixpkgs";
-    godoc.inputs.systems.follows = "systems";
-    godoc.inputs.blueprint.follows = "blueprint";
-    godoc.inputs.treefmt-nix.follows = "treefmt-nix";
-    godoc.inputs.flake-utils.follows = "flake-utils";
   };
 
   # Keep the magic invocations to minimum.

--- a/nix/devshells/docs.nix
+++ b/nix/devshells/docs.nix
@@ -1,29 +1,11 @@
 {
   pkgs,
-  perSystem,
   ...
 }:
 pkgs.mkShellNoCC {
-  packages =
-    with pkgs;
-    # Pop an empty shell on systems that aren't supported by godoc
-    lib.optionals (perSystem.godoc ? default) (
-      [
-        perSystem.godoc.default
-        (pkgs.writeScriptBin "gen-reference" ''
-          out="./docs/content/reference/go_doc"
-          godoc -c -o $out .
-        '')
-        (pkgs.writeScriptBin "mkdocs" ''
-          # generate reference docs first
-          gen-reference
-          # execute the underlying command
-          ${pkgs.mkdocs}/bin/mkdocs "$@"
-        '')
-      ]
-      ++ (with pkgs.python3Packages; [
-        mike
-        mkdocs-material
-      ])
-    );
+  packages = with pkgs.python3Packages; [
+    mike
+    mkdocs
+    mkdocs-material
+  ];
 }


### PR DESCRIPTION

we don't really expose a go api and godoc currently breaks with latest
nixpkgs
