### PR TITLE
Add UEFI boot detection to fix boot failures on UEFI-only systems

### DIFF
--- a/nix/packages/nixos-facter/tests/default.nix
+++ b/nix/packages/nixos-facter/tests/default.nix
@@ -52,6 +52,15 @@ pkgs.lib.optionalAttrs pkgs.stdenv.isx86_64 {
           # todo double-check this is the same for intel
           assert virt in ("kvm", "qemu"), f"expected virtualisation to be either kvm or qemu, got {virt}"
 
+      with subtest("Capture UEFI boot information"):
+          assert 'uefi' in report, "'uefi' not found in the report"
+
+          uefi = report['uefi']
+
+          assert uefi['supported'] == True, f"expected UEFI to be supported, got {uefi['supported']}"
+          assert 'platform_size' in uefi, "'platform_size' not found in uefi"
+          assert uefi['platform_size'] in (32, 64), f"expected platform_size to be 32 or 64, got {uefi['platform_size']}"
+
       with subtest("Capture swap entries"):
           assert 'swap' in report, "'swap' not found in the report"
 

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -1,0 +1,50 @@
+// Package boot contains utilities for detecting boot-related information.
+package boot
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	efiFirmwarePath     = "/sys/firmware/efi"
+	efiPlatformSizePath = "/sys/firmware/efi/fw_platform_size"
+)
+
+// UEFIInfo contains information about UEFI firmware support.
+type UEFIInfo struct {
+	// Supported indicates whether the system booted with UEFI.
+	Supported bool `json:"supported"`
+
+	// PlatformSize indicates the firmware platform size in bits (32 or 64).
+	// Only populated when Supported is true.
+	PlatformSize *uint8 `json:"platform_size,omitempty"`
+}
+
+// DetectUEFI detects UEFI boot information.
+func DetectUEFI() (*UEFIInfo, error) {
+	info := &UEFIInfo{}
+
+	// Check if the EFI firmware directory exists
+	if stat, err := os.Stat(efiFirmwarePath); err != nil || !stat.IsDir() {
+		slog.Debug("UEFI boot not detected", "path", efiFirmwarePath)
+		return info, nil
+	}
+
+	info.Supported = true
+	slog.Debug("UEFI boot detected", "path", efiFirmwarePath)
+
+	// Detect platform size (32 or 64 bit)
+	if data, err := os.ReadFile(efiPlatformSizePath); err == nil {
+		sizeStr := strings.TrimSpace(string(data))
+		if size, err := strconv.ParseUint(sizeStr, 10, 8); err == nil {
+			size8 := uint8(size)
+			info.PlatformSize = &size8
+			slog.Debug("UEFI platform size detected", "bits", size)
+		}
+	}
+
+	return info, nil
+}

--- a/pkg/facter/facter.go
+++ b/pkg/facter/facter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/numtide/nixos-facter/pkg/boot"
 	"github.com/numtide/nixos-facter/pkg/build"
 	"github.com/numtide/nixos-facter/pkg/ephem"
 	"github.com/numtide/nixos-facter/pkg/hwinfo"
@@ -25,7 +26,10 @@ type Report struct {
 	// Virtualisation indicates the type of virtualisation or container environment present on the system.
 	Virtualisation virt.Type `json:"virtualisation"`
 
-	// Hardware provides detailed information about the system’s hardware components, such as CPU, memory, and peripherals.
+	// UEFI contains information about UEFI firmware support.
+	UEFI *boot.UEFIInfo `json:"uefi"`
+
+	// Hardware provides detailed information about the system's hardware components, such as CPU, memory, and peripherals.
 	Hardware Hardware `json:"hardware,omitempty"`
 
 	// Smbios provides detailed information about the system's SMBios data, such as BIOS, board, chassis, memory,
@@ -115,6 +119,12 @@ func (s *Scanner) Scan() (*Report, error) {
 
 	if report.Virtualisation, err = virt.Detect(); err != nil {
 		return nil, fmt.Errorf("failed to detect virtualisation: %w", err)
+	}
+
+	slog.Debug("detecting UEFI")
+
+	if report.UEFI, err = boot.DetectUEFI(); err != nil {
+		return nil, fmt.Errorf("failed to detect UEFI: %w", err)
 	}
 
 	if s.Ephemeral || s.Swap {


### PR DESCRIPTION
This addresses systems that exclusively support UEFI boot (like newer Hetzner cloud machines) where facter previously had no way to detect the boot mode, causing installations to fail to boot.

This allows nixos-facter-modules to automatically set boot.loader.grub.efiSupport and related options based on hardware capabilities.

Fixes #217