### PR TITLE
Add better error handling for udev USB devices

### DIFF
--- a/pkg/udev/udev.go
+++ b/pkg/udev/udev.go
@@ -135,16 +135,16 @@ type Usb struct {
 }
 
 func parseUint16OrDefault(env map[string]string, key string) (uint16, error) {
-    if value := env[key]; value != "" {
-        parsed, err := strconv.ParseUint(value, 16, 16)
-        if err != nil {
-            slog.Warn("failed to parse udev key value", "key", key, "value", value, "error", err)
-            return 0, err
-        }
-        return uint16(parsed), nil
-    }
-    slog.Warn("udev key is empty or not found", "key", key)
-    return 0, nil
+	if value := env[key]; value != "" {
+		parsed, err := strconv.ParseUint(value, 16, 16)
+		if err != nil {
+			slog.Warn("failed to parse udev key value", "key", key, "value", value, "error", err)
+			return 0, err
+		}
+		return uint16(parsed), nil
+	}
+	slog.Warn("udev key is empty or not found", "key", key)
+	return 0, nil
 }
 
 func NewUdevUsb(env map[string]string) (*Usb, error) {


### PR DESCRIPTION
This PR addresses issue [227](https://github.com/nix-community/nixos-facter/issues/277) by adding some additional logging and a default value when parsing USB udev devices.

I was able to successfully run and get a facter.json when running this on the Dell Inspiron 13-7353 affected by the issue.