### PR TITLE
make systemd dependencies optional for non-systemd systems

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/numtide/nixos-facter/pkg/build"
@@ -87,18 +88,20 @@ Flags:
 }
 
 func Execute() {
-	// check udev version
-	if udevVersion, err := udev.Version(); err != nil {
-		log.Fatalf("failed to get systemd version: %v", err)
-	} else if udevVersion < 252 {
-		log.Fatalf("udev version %d is too old, please upgrade to at least 252", udevVersion)
-	}
-
 	flag.Parse()
 
 	if version {
 		fmt.Printf("%s\n", build.Version)
 		return
+	}
+
+	// check udev version
+	if _, err := exec.LookPath("udevadm"); err != nil {
+		slog.Warn("udevadm not found, skipping udev version check")
+	} else if udevVersion, err := udev.Version(); err != nil {
+		log.Fatalf("failed to get udev version: %v", err)
+	} else if udevVersion < 252 {
+		log.Fatalf("udev version %d is too old, please upgrade to at least 252", udevVersion)
 	}
 
 	// Check if the effective user id is 0 e.g. root

--- a/pkg/virt/virt.go
+++ b/pkg/virt/virt.go
@@ -53,7 +53,13 @@ const (
 // Detect identifies the virtualisation type of the current system.
 // Returns the detected Type and an error if detection fails.
 func Detect() (Type, error) {
-	out, err := exec.Command("systemd-detect-virt").CombinedOutput()
+	path, err := exec.LookPath("systemd-detect-virt")
+	if err != nil {
+		slog.Warn("systemd-detect-virt not found, skipping virtualisation detection")
+		return TypeNone, nil
+	}
+
+	out, err := exec.Command(path).CombinedOutput()
 	outStr := strings.Trim(string(out), "\n")
 
 	// note: systemd-detect-virt exits with status 1 when "none" is detected


### PR DESCRIPTION
i think `nixos-facter` could be _very_ useful for other nix based oses, like [finix](https://github.com/finix-community/finix)

i built `nixos-facter` with this code using [libudev-zero](https://github.com/illiliti/libudev-zero) and it produces useful `json` on my non-systemd based system

built via `pkgs.nixos-facter.override { systemdMinimal = pkgs.libudev-zero; }`

the basic idea is that since `libudev-zero` can provide the same information as `udev` we can just make the `udev` version check optional if `udevadm` isn't available... ie. we're on a system that isn't `systemd` based


... let me know what you think :eyes: