### PR TITLE
udev: drop Bus field, dispatch on `ID_BUS` string

### DIFF
--- a/pkg/udev/udev.go
+++ b/pkg/udev/udev.go
@@ -53,8 +53,6 @@ import (
 	"strconv"
 	"strings"
 	"unsafe"
-
-	"github.com/numtide/nixos-facter/pkg/linux/input"
 )
 
 //go:generate enumer -type=Type -json -text -trimprefix Type -output=./udev_type.go
@@ -193,7 +191,6 @@ func NewUdevPci(env map[string]string) (*Pci, error) {
 }
 
 type Udev struct {
-	Bus         input.Bus
 	Type        Type
 	Model       string
 	ModelID     uint16
@@ -215,12 +212,6 @@ func NewUdev(env map[string]string) (*Udev, error) {
 		Serial:      env["ID_SERIAL"],
 		SerialShort: env["ID_SERIAL_SHORT"],
 		Input:       NewUdevInput(env),
-	}
-
-	if bus, ok := env["ID_BUS"]; ok {
-		if err := result.Bus.UnmarshalText([]byte(bus)); err != nil {
-			return nil, fmt.Errorf("failed to parse bus: %w", err)
-		}
 	}
 
 	if str, ok := env["ID_MODEL_ID"]; ok {
@@ -250,19 +241,20 @@ func NewUdev(env map[string]string) (*Udev, error) {
 		result.Revision = uint16(revision)
 	}
 
+	// ID_BUS is set by systemd-udev rules and has an open-ended value space
+	// (usb, pci, scsi, ata, acpi, platform, virtio, ...); only dispatch on
+	// the buses we have parsers for. See issue #554.
 	var err error
 
-	//nolint:exhaustive
-	switch result.Bus {
-	case input.BusUsb:
+	switch env["ID_BUS"] {
+	case "usb":
 		if result.Usb, err = NewUdevUsb(env); err != nil {
 			return nil, fmt.Errorf("failed to parse usb: %w", err)
 		}
-	case input.BusPci:
+	case "pci":
 		if result.Pci, err = NewUdevPci(env); err != nil {
 			return nil, fmt.Errorf("failed to parse pci: %w", err)
 		}
-	default: // do nothing
 	}
 
 	return result, nil

--- a/pkg/udev/udev_test.go
+++ b/pkg/udev/udev_test.go
@@ -1,0 +1,26 @@
+package udev_test
+
+import (
+	"testing"
+
+	"github.com/numtide/nixos-facter/pkg/udev"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewUdevAcpiBus reproduces issue #554: systemd >= 260 tags ACPI input
+// devices (e.g. LNXPWRBN, LNXVIDEO) with ID_BUS=acpi, which previously aborted
+// the whole hardware scan because the udev parser tried to coerce ID_BUS into
+// the kernel input.Bus enum that has no acpi member.
+func TestNewUdevAcpiBus(t *testing.T) {
+	t.Parallel()
+
+	result, err := udev.NewUdev(map[string]string{
+		"ID_BUS":       "acpi",
+		"ID_INPUT":     "1",
+		"ID_INPUT_KEY": "1",
+	})
+	require.NoError(t, err, "NewUdev must accept ID_BUS=acpi without error")
+	require.NotNil(t, result)
+	require.NotNil(t, result.Input)
+	require.True(t, result.Input.IsKey)
+}


### PR DESCRIPTION
`ID_BUS` is a `udev`-provided string, not a Linux input bus enum.
`systemd-udev` can report other values such as `acpi`(systemd v260),
which caused NewUdev to fail while parsing
the field before any input metadata could be used.
This is likely to happen in other updates of `systemd` as well.

Remove the `Udev.Bus` field and dispatch only the supported nested
parsers directly from env["ID_BUS"] for `usb` and `pci`.
Other values are accepted without bus-specific parsing -
and no strict validation.

Add a regression test for `ID_BUS=acpi`.

Closes: #554
