### PR TITLE
docs(readme): add disko dependency warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **⚠️ Warning:** `nixos-facter` has a hard dependency on [`disko`](https://github.com/nix-community/disko) and might silently brick any device which does not have a `disko.nix` file imported into its NixOS config.
+
 # NixOS Facter
 
 NixOS Facter aims to be an alternative to projects such as [NixOS Hardware] and [nixos-generate-config].


### PR DESCRIPTION
The proper fix would probably be to bail out during eval if disks are not defined, but to prevent more people bricking their devices with nixos-facter, this warning should be sufficient in the mean time.