### PR TITLE
General update and refresh

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,10 +16,16 @@ linters:
         - tagliatelle
         - nlreturn
         - gochecknoglobals
+        - wsl
+        - gomodguard
 
     settings:
         cyclop:
             max-complexity: 15
+        wsl_v5:
+            allow-first-in-block: true
+            allow-whole-block: false
+            branch-max-lines: 2
         revive:
             rules:
                 - name: "exported"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,12 +96,18 @@ func Execute() {
 	}
 
 	// check udev version
-	if _, err := exec.LookPath("udevadm"); err != nil {
+	_, err := exec.LookPath("udevadm")
+	if err != nil {
 		slog.Warn("udevadm not found, skipping udev version check")
-	} else if udevVersion, err := udev.Version(); err != nil {
-		log.Fatalf("failed to get udev version: %v", err)
-	} else if udevVersion < 252 {
-		log.Fatalf("udev version %d is too old, please upgrade to at least 252", udevVersion)
+	} else {
+		udevVersion, err := udev.Version()
+		if err != nil {
+			log.Fatalf("failed to get udev version: %v", err)
+		}
+
+		if udevVersion < 252 {
+			log.Fatalf("udev version %d is too old, please upgrade to at least 252", udevVersion)
+		}
 	}
 
 	// Check if the effective user id is 0 e.g. root
@@ -122,7 +128,9 @@ func Execute() {
 	// Set the log level
 
 	var slogLevel slog.Level
-	if err := slogLevel.UnmarshalText([]byte(logLevel)); err != nil {
+
+	err = slogLevel.UnmarshalText([]byte(logLevel))
+	if err != nil {
 		log.Fatalf("invalid log level: %v", err)
 	}
 
@@ -151,12 +159,16 @@ func Execute() {
 
 	// If a file path is provided write the report to it, otherwise output the report on stdout
 	if outputPath == "" {
-		if _, err = os.Stdout.Write(bytes); err != nil {
+		_, err = os.Stdout.Write(bytes)
+		if err != nil {
 			log.Fatalf("failed to write report to stdout: %v", err)
 		}
 
 		fmt.Println()
-	} else if err = os.WriteFile(outputPath, bytes, 0o600); err != nil {
-		log.Fatalf("failed to write report to output path: %v", err)
+	} else {
+		err = os.WriteFile(outputPath, bytes, 0o600)
+		if err != nil {
+			log.Fatalf("failed to write report to output path: %v", err)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/numtide/nixos-facter
 
-go 1.24.1
+go 1.26.4
 
 require github.com/stretchr/testify v1.11.1
 

--- a/nix/devshells/default.nix
+++ b/nix/devshells/default.nix
@@ -13,7 +13,7 @@ let
     pkgs.cobra-cli
     pkgs.fx # json tui
   ];
-  go = pkgs.go_1_25;
+  go = pkgs.go_1_26;
 in
 if stdenv.hostPlatform.isLinux then
   perSystem.self.nixos-facter.overrideAttrs (old: {

--- a/nix/packages/nixos-facter/package.nix
+++ b/nix/packages/nixos-facter/package.nix
@@ -6,13 +6,13 @@
   makeWrapper,
   pkg-config,
   stdenv,
-  buildGo125Module,
+  buildGo126Module,
   versionCheckHook,
 }:
 let
   fs = lib.fileset;
 in
-buildGo125Module (final: {
+buildGo126Module (final: {
   pname = "nixos-facter";
   version = "0.4.4";
 

--- a/nix/packages/nixos-facter/package.nix
+++ b/nix/packages/nixos-facter/package.nix
@@ -19,6 +19,7 @@ buildGo126Module (final: {
   src = fs.toSource {
     root = ../../..;
     fileset = fs.unions [
+      ../../../.golangci.yml
       ../../../cmd
       ../../../go.mod
       ../../../go.sum

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -2,6 +2,9 @@
 package boot
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"strconv"
@@ -28,20 +31,31 @@ func DetectUEFI() (*UEFIInfo, error) {
 	info := &UEFIInfo{}
 
 	// Check if the EFI firmware directory exists
-	if stat, err := os.Stat(efiFirmwarePath); err != nil || !stat.IsDir() {
+	stat, err := os.Stat(efiFirmwarePath)
+	if errors.Is(err, fs.ErrNotExist) || (err == nil && !stat.IsDir()) {
 		slog.Debug("UEFI boot not detected", "path", efiFirmwarePath)
+
 		return info, nil
 	}
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %s: %w", efiFirmwarePath, err)
+	}
+
 	info.Supported = true
+
 	slog.Debug("UEFI boot detected", "path", efiFirmwarePath)
 
 	// Detect platform size (32 or 64 bit)
-	if data, err := os.ReadFile(efiPlatformSizePath); err == nil {
+	data, err := os.ReadFile(efiPlatformSizePath)
+	if err == nil {
 		sizeStr := strings.TrimSpace(string(data))
-		if size, err := strconv.ParseUint(sizeStr, 10, 8); err == nil {
+
+		size, err := strconv.ParseUint(sizeStr, 10, 8)
+		if err == nil {
 			size8 := uint8(size)
 			info.PlatformSize = &size8
+
 			slog.Debug("UEFI platform size detected", "bits", size)
 		}
 	}

--- a/pkg/ephem/swap.go
+++ b/pkg/ephem/swap.go
@@ -68,6 +68,7 @@ func SwapEntries() ([]*SwapEntry, error) {
 		if devices[i].Priority != devices[j].Priority {
 			return devices[i].Priority < devices[j].Priority
 		}
+
 		return devices[i].Filename < devices[j].Filename
 	})
 

--- a/pkg/facter/facter.go
+++ b/pkg/facter/facter.go
@@ -30,11 +30,11 @@ type Report struct {
 	UEFI *boot.UEFIInfo `json:"uefi"`
 
 	// Hardware provides detailed information about the system's hardware components, such as CPU, memory, and peripherals.
-	Hardware Hardware `json:"hardware,omitempty"`
+	Hardware Hardware `json:"hardware"`
 
 	// Smbios provides detailed information about the system's SMBios data, such as BIOS, board, chassis, memory,
 	// and processors.
-	Smbios Smbios `json:"smbios,omitempty"`
+	Smbios Smbios `json:"smbios"`
 
 	// Swap contains a list of swap entries representing the system's swap devices or files and their respective details.
 	Swap []*ephem.SwapEntry `json:"swap,omitempty"`
@@ -102,7 +102,8 @@ func (s *Scanner) Scan() (*Report, error) {
 			device.SysfsIOMMUGroupID = &groupID
 		}
 
-		if err = report.Hardware.add(device); err != nil {
+		err = report.Hardware.add(device)
+		if err != nil {
 			return nil, fmt.Errorf("failed to add to hardware report: %w", err)
 		}
 	}
@@ -110,27 +111,31 @@ func (s *Scanner) Scan() (*Report, error) {
 	slog.Debug("processing smbios entries", "count", len(smbios))
 
 	for idx := range smbios {
-		if err = report.Smbios.add(smbios[idx]); err != nil {
+		err = report.Smbios.add(smbios[idx])
+		if err != nil {
 			return nil, fmt.Errorf("failed to add to smbios report: %w", err)
 		}
 	}
 
 	slog.Debug("detecting virtualisation")
 
-	if report.Virtualisation, err = virt.Detect(); err != nil {
+	report.Virtualisation, err = virt.Detect()
+	if err != nil {
 		return nil, fmt.Errorf("failed to detect virtualisation: %w", err)
 	}
 
 	slog.Debug("detecting UEFI")
 
-	if report.UEFI, err = boot.DetectUEFI(); err != nil {
+	report.UEFI, err = boot.DetectUEFI()
+	if err != nil {
 		return nil, fmt.Errorf("failed to detect UEFI: %w", err)
 	}
 
 	if s.Ephemeral || s.Swap {
 		slog.Debug("processing swap devices")
 
-		if report.Swap, err = ephem.SwapEntries(); err != nil {
+		report.Swap, err = ephem.SwapEntries()
+		if err != nil {
 			return nil, fmt.Errorf("failed to detect swap devices: %w", err)
 		}
 	}

--- a/pkg/facter/hardware.go
+++ b/pkg/facter/hardware.go
@@ -208,6 +208,11 @@ func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 
 	switch class {
 	case hwinfo.HardwareClassBios:
+		if device.Detail == nil {
+			// BIOS detail data unavailable
+			return nil
+		}
+
 		if h.Bios != nil {
 			return errors.New("bios field is already set")
 		} else if bios, ok := device.Detail.(*hwinfo.DetailBios); !ok {
@@ -237,13 +242,14 @@ func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 		h.ChipCard = append(h.ChipCard, device)
 		slices.SortFunc(h.ChipCard, compareDevice)
 	case hwinfo.HardwareClassCpu:
+		if device.Detail == nil {
+			// CPU detail data unavailable (can happen on some hypervisors)
+			return nil
+		}
+
 		cpu, ok := device.Detail.(*hwinfo.DetailCPU)
 		if !ok {
 			return fmt.Errorf("expected hwinfo.DetailCPU, found %T", device.Detail)
-		}
-		if cpu == nil {
-			// CPU detail data unavailable (can happen on some hypervisors)
-			return nil
 		}
 
 		// We insert by physical id, as we only want one entry per core.
@@ -388,6 +394,11 @@ func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 		h.StorageController = append(h.StorageController, device)
 		slices.SortFunc(h.StorageController, compareDevice)
 	case hwinfo.HardwareClassSystem:
+		if device.Detail == nil {
+			// system detail data unavailable
+			return nil
+		}
+
 		if h.System != nil {
 			return errors.New("system field is already set")
 		} else if system, ok := device.Detail.(*hwinfo.DetailSys); !ok {

--- a/pkg/hwinfo/detail.go
+++ b/pkg/hwinfo/detail.go
@@ -47,6 +47,11 @@ const (
 	DetailTypeJoystick
 )
 
+// ErrDetailMissing indicates hwinfo returned a detail structure with a NULL
+// data pointer: the detail is absent rather than malformed. See hdp.c:1082
+// and hdp.c:1204 for hwinfo's own handling.
+var ErrDetailMissing = errors.New("detail data is missing")
+
 type Detail interface {
 	DetailType() DetailType
 }
@@ -85,7 +90,11 @@ func NewDetail(detail *C.hd_detail_t) (Detail, error) {
 		err = fmt.Errorf("unknown detail type %d", DetailType(C.hd_detail_get_type(detail)))
 	}
 
-	return result, err
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }
 
 type MemoryRange struct {

--- a/pkg/hwinfo/detail_bios.go
+++ b/pkg/hwinfo/detail_bios.go
@@ -46,16 +46,12 @@ type DetailBios struct {
 	// todo bios32
 }
 
-func (d DetailBios) DetailType() DetailType {
-	return DetailTypeBios
-}
-
 func NewDetailBios(dev C.hd_detail_bios_t) (*DetailBios, error) {
 	data := dev.data
 	if data == nil {
 		// Not an error: hwinfo can return detail structures with NULL data pointers.
 		// See hdp.c:1204 for hwinfo's own handling.
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	return &DetailBios{
@@ -77,4 +73,8 @@ func NewDetailBios(dev C.hd_detail_bios_t) (*DetailBios, error) {
 		LowMemorySize: uint32(data.low_mem_size),
 		SmbiosVersion: uint32(data.smbios_ver),
 	}, nil
+}
+
+func (d DetailBios) DetailType() DetailType {
+	return DetailTypeBios
 }

--- a/pkg/hwinfo/detail_cpu.go
+++ b/pkg/hwinfo/detail_cpu.go
@@ -81,7 +81,7 @@ type DetailCPU struct {
 	TlbSize        uint16       `json:"tlb_size,omitempty"`
 	ClflushSize    uint16       `json:"clflush_size,omitempty"`
 	CacheAlignment int          `json:"cache_alignment,omitempty"`
-	AddressSizes   AddressSizes `json:"address_sizes,omitempty"`
+	AddressSizes   AddressSizes `json:"address_sizes"`
 	Apicid         uint         `json:"-"`
 	ApicidInitial  uint         `json:"-"`
 }
@@ -99,7 +99,7 @@ func NewDetailCPU(cpu C.hd_detail_cpu_t) (*DetailCPU, error) {
 		// Not an error: hwinfo can return detail structures with NULL data pointers
 		// on certain systems (e.g., older VMware ESXi). See hdp.c:1082 for hwinfo's
 		// own handling: if(!(ct = hd->detail->cpu.data)) return;
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	return &DetailCPU{

--- a/pkg/hwinfo/detail_isa_pnp_dev.go
+++ b/pkg/hwinfo/detail_isa_pnp_dev.go
@@ -69,15 +69,11 @@ type DetailIsaPnpDevice struct {
 	Flags  uint32      `json:"flags"`
 }
 
-func (d DetailIsaPnpDevice) DetailType() DetailType {
-	return DetailTypeIsaPnp
-}
-
 func NewDetailIsaPnpDevice(pnp C.hd_detail_isapnp_t) (*DetailIsaPnpDevice, error) {
 	data := pnp.data
 	if data == nil {
 		// Not an error: hwinfo can return detail structures with NULL data pointers.
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	card, err := NewIsaPnpCard(data.card)
@@ -91,4 +87,8 @@ func NewDetailIsaPnpDevice(pnp C.hd_detail_isapnp_t) (*DetailIsaPnpDevice, error
 		Device: uint32(data.dev),
 		Flags:  uint32(data.flags),
 	}, nil
+}
+
+func (d DetailIsaPnpDevice) DetailType() DetailType {
+	return DetailTypeIsaPnp
 }

--- a/pkg/hwinfo/detail_monitor.go
+++ b/pkg/hwinfo/detail_monitor.go
@@ -39,15 +39,11 @@ type DetailMonitor struct {
 	Serial string `json:"-"`
 }
 
-func (d DetailMonitor) DetailType() DetailType {
-	return DetailTypeMonitor
-}
-
 func NewDetailMonitor(mon C.hd_detail_monitor_t) (*DetailMonitor, error) {
 	data := mon.data
 	if data == nil {
 		// Not an error: hwinfo can return detail structures with NULL data pointers.
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	return &DetailMonitor{
@@ -85,4 +81,8 @@ func NewDetailMonitor(mon C.hd_detail_monitor_t) (*DetailMonitor, error) {
 		Name:           C.GoString(data.name),
 		Serial:         C.GoString(data.serial),
 	}, nil
+}
+
+func (d DetailMonitor) DetailType() DetailType {
+	return DetailTypeMonitor
 }

--- a/pkg/hwinfo/detail_pci.go
+++ b/pkg/hwinfo/detail_pci.go
@@ -83,16 +83,12 @@ type DetailPci struct {
 	Log           string `json:"-"` // log messages
 }
 
-func (p DetailPci) DetailType() DetailType {
-	return DetailTypePci
-}
-
 func NewDetailPci(pci C.hd_detail_pci_t) (*DetailPci, error) {
 	data := pci.data
 	if data == nil {
 		// Not an error: hwinfo can return detail structures with NULL data pointers.
 		// See pci.c:497 for hwinfo's own handling.
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	return &DetailPci{
@@ -127,4 +123,8 @@ func NewDetailPci(pci C.hd_detail_pci_t) (*DetailPci, error) {
 		ModuleAlias:    C.GoString(data.modalias),
 		Label:          C.GoString(data.label),
 	}, nil
+}
+
+func (p DetailPci) DetailType() DetailType {
+	return DetailTypePci
 }

--- a/pkg/hwinfo/detail_sys.go
+++ b/pkg/hwinfo/detail_sys.go
@@ -17,16 +17,12 @@ type DetailSys struct {
 	FormFactor string     `json:"form_factor,omitempty"`
 }
 
-func (d DetailSys) DetailType() DetailType {
-	return DetailTypeSys
-}
-
 func NewDetailSys(sys C.hd_detail_sys_t) (*DetailSys, error) {
 	data := sys.data
 	if data == nil {
 		// Not an error: hwinfo can return detail structures with NULL data pointers.
 		// See hdp.c:1302 for hwinfo's own handling.
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	return &DetailSys{
@@ -39,4 +35,8 @@ func NewDetailSys(sys C.hd_detail_sys_t) (*DetailSys, error) {
 		Language:   C.GoString(data.lang),
 		FormFactor: C.GoString(data.formfactor),
 	}, nil
+}
+
+func (d DetailSys) DetailType() DetailType {
+	return DetailTypeSys
 }

--- a/pkg/hwinfo/detail_usb.go
+++ b/pkg/hwinfo/detail_usb.go
@@ -59,15 +59,11 @@ type DetailUsbInterfaceAssociation struct {
 	FirstInterface   int `json:"first_interface"`
 }
 
-func (d DetailUsb) DetailType() DetailType {
-	return DetailTypeUsb
-}
-
 func NewDetailUsb(usb C.hd_detail_usb_t) (*DetailUsb, error) {
 	data := usb.data
 	if data == nil {
 		// Not an error: hwinfo can return detail structures with NULL data pointers.
-		return nil, nil
+		return nil, ErrDetailMissing
 	}
 
 	if data.next != nil {
@@ -124,4 +120,8 @@ func NewDetailUsb(usb C.hd_detail_usb_t) (*DetailUsb, error) {
 	}
 
 	return detail, nil
+}
+
+func (d DetailUsb) DetailType() DetailType {
+	return DetailTypeUsb
 }

--- a/pkg/hwinfo/driver_info_display.go
+++ b/pkg/hwinfo/driver_info_display.go
@@ -23,10 +23,6 @@ type DriverInfoDisplay struct {
 	VerticalFlag          byte        `json:"vertical_flag"`
 }
 
-func (d DriverInfoDisplay) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeDisplay
-}
-
 func NewDriverInfoDisplay(info C.driver_info_display_t) DriverInfoDisplay {
 	return DriverInfoDisplay{
 		Type:     DriverInfoTypeDisplay,
@@ -57,4 +53,8 @@ func NewDriverInfoDisplay(info C.driver_info_display_t) DriverInfoDisplay {
 		HorizontalFlag: byte(info.hflag),
 		VerticalFlag:   byte(info.vflag),
 	}
+}
+
+func (d DriverInfoDisplay) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeDisplay
 }

--- a/pkg/hwinfo/driver_info_dsl.go
+++ b/pkg/hwinfo/driver_info_dsl.go
@@ -16,10 +16,6 @@ type DriverInfoDsl struct {
 	Name string `json:"name,omitempty"` // DSL driver name
 }
 
-func (d DriverInfoDsl) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeDsl
-}
-
 func NewDriverInfoDsl(info C.driver_info_dsl_t) DriverInfoDsl {
 	return DriverInfoDsl{
 		Type:     DriverInfoTypeDsl,
@@ -28,4 +24,8 @@ func NewDriverInfoDsl(info C.driver_info_dsl_t) DriverInfoDsl {
 		Mode:     C.GoString(info.mode),
 		Name:     C.GoString(info.name),
 	}
+}
+
+func (d DriverInfoDsl) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeDsl
 }

--- a/pkg/hwinfo/driver_info_isdn.go
+++ b/pkg/hwinfo/driver_info_isdn.go
@@ -18,10 +18,6 @@ type DriverInfoIsdn struct {
 	// todo isdn params
 }
 
-func (d DriverInfoIsdn) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeIsdn
-}
-
 func NewDriverInfoIsdn(info C.driver_info_isdn_t) DriverInfoIsdn {
 	return DriverInfoIsdn{
 		Type:       DriverInfoTypeIsdn,
@@ -31,4 +27,8 @@ func NewDriverInfoIsdn(info C.driver_info_isdn_t) DriverInfoIsdn {
 		I4lSubtype: int(info.i4l_subtype),
 		I4lName:    C.GoString(info.i4l_name),
 	}
+}
+
+func (d DriverInfoIsdn) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeIsdn
 }

--- a/pkg/hwinfo/driver_info_keyboard.go
+++ b/pkg/hwinfo/driver_info_keyboard.go
@@ -18,10 +18,6 @@ type DriverInfoKeyboard struct {
 	Keymap    string `json:"keymap,omitempty"`
 }
 
-func (d DriverInfoKeyboard) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeKeyboard
-}
-
 func NewDriverInfoKeyboard(info C.driver_info_kbd_t) DriverInfoKeyboard {
 	return DriverInfoKeyboard{
 		Type:      DriverInfoTypeKeyboard,
@@ -32,4 +28,8 @@ func NewDriverInfoKeyboard(info C.driver_info_kbd_t) DriverInfoKeyboard {
 		XkbLayout: C.GoString(info.XkbLayout),
 		Keymap:    C.GoString(info.keymap),
 	}
+}
+
+func (d DriverInfoKeyboard) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeKeyboard
 }

--- a/pkg/hwinfo/driver_info_module.go
+++ b/pkg/hwinfo/driver_info_module.go
@@ -24,10 +24,6 @@ type DriverInfoModule struct {
 	Conf       string   `json:"conf"`        // conf.modules entry, if any (e.g., for sb.o)
 }
 
-func (d DriverInfoModule) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeModule
-}
-
 func NewDriverInfoModule(info C.driver_info_module_t) DriverInfoModule {
 	return DriverInfoModule{
 		Type:       DriverInfoTypeModule,
@@ -39,4 +35,8 @@ func NewDriverInfoModule(info C.driver_info_module_t) DriverInfoModule {
 		ModuleArgs: ReadStringList(info.mod_args),
 		Conf:       C.GoString(info.conf),
 	}
+}
+
+func (d DriverInfoModule) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeModule
 }

--- a/pkg/hwinfo/driver_info_mouse.go
+++ b/pkg/hwinfo/driver_info_mouse.go
@@ -18,10 +18,6 @@ type DriverInfoMouse struct {
 	Wheels  int    `json:"wheels,omitempty"`  // dto, wheels
 }
 
-func (d DriverInfoMouse) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeMouse
-}
-
 func NewDriverInfoMouse(info C.driver_info_mouse_t) DriverInfoMouse {
 	return DriverInfoMouse{
 		Type:     DriverInfoTypeMouse,
@@ -32,4 +28,8 @@ func NewDriverInfoMouse(info C.driver_info_mouse_t) DriverInfoMouse {
 		Buttons:  int(info.buttons),
 		Wheels:   int(info.wheels),
 	}
+}
+
+func (d DriverInfoMouse) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeMouse
 }

--- a/pkg/hwinfo/driver_info_x11.go
+++ b/pkg/hwinfo/driver_info_x11.go
@@ -33,16 +33,12 @@ type DriverInfoX11 struct {
 		C16 byte `json:"c16"`
 		C24 byte `json:"c24"`
 		C32 byte `json:"c32"`
-	} `json:",omitempty"`
+	}
 	DacSpeed   uint32   `json:"dac_speed"`            // max. ramdac clock
 	Extensions []string `json:"extensions,omitempty"` // additional X extensions to load ('Module' section)
 	Options    []string `json:"options,omitempty"`    // special server options
 	Raw        []string `json:"raw,omitempty"`        // extra info to add to XF86Config
 	Script     string   `json:"script"`               // 3d script to run
-}
-
-func (d DriverInfoX11) DriverInfoType() DriverInfoType {
-	return DriverInfoTypeX11
 }
 
 func NewDriverInfoX11(info C.driver_info_x11_t) DriverInfoX11 {
@@ -68,4 +64,8 @@ func NewDriverInfoX11(info C.driver_info_x11_t) DriverInfoX11 {
 	result.Colors.C32 = byte(C.driver_info_x11_colors_c32(info))
 
 	return result
+}
+
+func (d DriverInfoX11) DriverInfoType() DriverInfoType {
+	return DriverInfoTypeX11
 }

--- a/pkg/hwinfo/hardware.go
+++ b/pkg/hwinfo/hardware.go
@@ -215,8 +215,9 @@ const (
 	BaseClassSerial
 	BaseClassWireless
 	BaseClassI2o
-	BaseClassOther BaseClass = 0xff
 )
+
+const BaseClassOther BaseClass = 0xff
 
 // add our own base classes here (starting at 0x100 as PCI values are 8 bit)
 const (
@@ -272,8 +273,9 @@ const (
 	SubClassMouseBus
 	SubClassMouseUsb
 	SubClassMouseSun
-	SubClassMouseOther SubClassMouse = 0x80
 )
+
+const SubClassMouseOther SubClassMouse = 0x80
 
 // Slot represents a bus and slot number.
 // Bits 0-7: slot number, 8-31 bus number
@@ -315,11 +317,6 @@ type DeviceNumber struct {
 	Range uint32 `json:"range"`
 }
 
-// IsEmpty checks if the DeviceNumber has all zero values for its fields.
-func (d DeviceNumber) IsEmpty() bool {
-	return d.Type == 0 && d.Major == 0 && d.Minor == 0 && d.Range == 0
-}
-
 // NewDeviceNumber creates a new DeviceNumber instance from the given C.hd_dev_num_t and returns a pointer to it.
 // Returns nil if the newly created DeviceNumber is empty.
 func NewDeviceNumber(num C.hd_dev_num_t) *DeviceNumber {
@@ -334,6 +331,11 @@ func NewDeviceNumber(num C.hd_dev_num_t) *DeviceNumber {
 	}
 
 	return &result
+}
+
+// IsEmpty checks if the DeviceNumber has all zero values for its fields.
+func (d DeviceNumber) IsEmpty() bool {
+	return d.Type == 0 && d.Major == 0 && d.Minor == 0 && d.Range == 0
 }
 
 // Hotplug defines types of hotplug devices.
@@ -566,9 +568,11 @@ func NewHardwareDevice(hd *C.hd_t, ephemeral bool) (*HardwareDevice, error) {
 	}
 
 	if hd.detail != nil {
-		detail, err = NewDetail(hd.detail)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read detail: %w", err)
+		var detailErr error
+
+		detail, detailErr = NewDetail(hd.detail)
+		if detailErr != nil && !errors.Is(detailErr, ErrDetailMissing) {
+			return nil, fmt.Errorf("failed to read detail: %w", detailErr)
 		}
 	}
 

--- a/pkg/hwinfo/id.go
+++ b/pkg/hwinfo/id.go
@@ -37,6 +37,37 @@ type idJSON struct {
 	Value uint16 `json:"value"`
 }
 
+func NewID(id C.hd_id_t) *ID {
+	result := ID{
+		/*
+			 	ID is actually a combination of some tag to differentiate the various id types and the real id.
+				We do the same thing as the ID_VALUE macro in hd.h to get the true value.
+		*/
+		Type:  IDTag((id.id >> 16) & 0xf),
+		Value: uint16(id.id),
+		Name:  C.GoString(id.name),
+	}
+	if result.IsEmpty() {
+		return nil
+	}
+
+	return &result
+}
+
+func NewBusID(bus Bus) *ID {
+	return &ID{
+		Name:  bus.String(),
+		Value: uint16(bus),
+	}
+}
+
+func NewBaseClassID(bc BaseClass) *ID {
+	return &ID{
+		Name:  bc.String(),
+		Value: uint16(bc),
+	}
+}
+
 func (i ID) MarshalJSON() ([]byte, error) {
 	var (
 		b   []byte
@@ -75,35 +106,4 @@ func (i ID) String() string {
 
 func (i ID) Is(ids ...uint16) bool {
 	return slices.Contains(ids, i.Value)
-}
-
-func NewID(id C.hd_id_t) *ID {
-	result := ID{
-		/*
-			 	ID is actually a combination of some tag to differentiate the various id types and the real id.
-				We do the same thing as the ID_VALUE macro in hd.h to get the true value.
-		*/
-		Type:  IDTag((id.id >> 16) & 0xf),
-		Value: uint16(id.id),
-		Name:  C.GoString(id.name),
-	}
-	if result.IsEmpty() {
-		return nil
-	}
-
-	return &result
-}
-
-func NewBusID(bus Bus) *ID {
-	return &ID{
-		Name:  bus.String(),
-		Value: uint16(bus),
-	}
-}
-
-func NewBaseClassID(bc BaseClass) *ID {
-	return &ID{
-		Name:  bc.String(),
-		Value: uint16(bc),
-	}
 }

--- a/pkg/hwinfo/input.go
+++ b/pkg/hwinfo/input.go
@@ -18,7 +18,7 @@ func captureTouchpads(deviceIdx uint16) ([]HardwareDevice, error) {
 		return nil, fmt.Errorf("failed to read input devices: %w", err)
 	}
 
-	var result []HardwareDevice //nolint:prealloc
+	var result []HardwareDevice
 
 	for _, inputDevice := range inputDevices {
 		path := "/sys" + inputDevice.Sysfs

--- a/pkg/hwinfo/resource_baud.go
+++ b/pkg/hwinfo/resource_baud.go
@@ -23,10 +23,6 @@ type ResourceBaud struct {
 	Handshake byte         `json:"handshake"`
 }
 
-func (r ResourceBaud) ResourceType() ResourceType {
-	return ResourceTypeBaud
-}
-
 func NewResourceBaud(res *C.hd_res_t, resType ResourceType) (*ResourceBaud, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -46,4 +42,8 @@ func NewResourceBaud(res *C.hd_res_t, resType ResourceType) (*ResourceBaud, erro
 		Parity:    byte(baud.parity),
 		Handshake: byte(baud.handshake),
 	}, nil
+}
+
+func (r ResourceBaud) ResourceType() ResourceType {
+	return ResourceTypeBaud
 }

--- a/pkg/hwinfo/resource_cache.go
+++ b/pkg/hwinfo/resource_cache.go
@@ -19,10 +19,6 @@ type ResourceCache struct {
 	Size string       `json:"size"`
 }
 
-func (r ResourceCache) ResourceType() ResourceType {
-	return ResourceTypeCache
-}
-
 func NewResourceCache(res *C.hd_res_t, resType ResourceType) (*ResourceCache, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -38,4 +34,8 @@ func NewResourceCache(res *C.hd_res_t, resType ResourceType) (*ResourceCache, er
 		Type: resType,
 		Size: fmt.Sprintf("0x%x", uint(cache.size)),
 	}, nil
+}
+
+func (r ResourceCache) ResourceType() ResourceType {
+	return ResourceTypeCache
 }

--- a/pkg/hwinfo/resource_disk_geo.go
+++ b/pkg/hwinfo/resource_disk_geo.go
@@ -33,10 +33,6 @@ type ResourceDiskGeo struct {
 	GeoType   GeoType      `json:"geo_type"`
 }
 
-func (r ResourceDiskGeo) ResourceType() ResourceType {
-	return ResourceTypeDiskGeo
-}
-
 func NewResourceDiskGeo(res *C.hd_res_t, resType ResourceType) (*ResourceDiskGeo, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -56,4 +52,8 @@ func NewResourceDiskGeo(res *C.hd_res_t, resType ResourceType) (*ResourceDiskGeo
 		Size:      fmt.Sprintf("0x%x", uint64(disk.size)),
 		GeoType:   GeoType(disk.geotype),
 	}, nil
+}
+
+func (r ResourceDiskGeo) ResourceType() ResourceType {
+	return ResourceTypeDiskGeo
 }

--- a/pkg/hwinfo/resource_dma.go
+++ b/pkg/hwinfo/resource_dma.go
@@ -25,10 +25,6 @@ type ResourceDma struct {
 	Enabled bool         `json:"enabled"`
 }
 
-func (r ResourceDma) ResourceType() ResourceType {
-	return ResourceTypeDma
-}
-
 func NewResourceDma(res *C.hd_res_t, resType ResourceType) (*ResourceDma, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -45,4 +41,8 @@ func NewResourceDma(res *C.hd_res_t, resType ResourceType) (*ResourceDma, error)
 		Base:    fmt.Sprintf("0x%x", uint(dma.base)),
 		Enabled: bool(C.hd_res_dma_get_enabled(dma)),
 	}, nil
+}
+
+func (r ResourceDma) ResourceType() ResourceType {
+	return ResourceTypeDma
 }

--- a/pkg/hwinfo/resource_fc.go
+++ b/pkg/hwinfo/resource_fc.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-// todo what is FC?
+// ResourceFc describes a fibre channel resource.
 type ResourceFc struct {
 	Type         ResourceType `json:"type"`
 	WwpnOk       bool         `json:"wwpn_ok"`
@@ -30,10 +30,6 @@ type ResourceFc struct {
 	FcpLun       uint64       `json:"fcp_lun"`
 	PortID       uint32       `json:"port_id"`
 	ControllerID byte         `json:"controller_id"`
-}
-
-func (r ResourceFc) ResourceType() ResourceType {
-	return ResourceTypeFc
 }
 
 func NewResourceFc(res *C.hd_res_t, resType ResourceType) (*ResourceFc, error) {
@@ -60,4 +56,8 @@ func NewResourceFc(res *C.hd_res_t, resType ResourceType) (*ResourceFc, error) {
 		PortID:       uint32(fc.port_id),
 		ControllerID: controllerID,
 	}, nil
+}
+
+func (r ResourceFc) ResourceType() ResourceType {
+	return ResourceTypeFc
 }

--- a/pkg/hwinfo/resource_frame_buffer.go
+++ b/pkg/hwinfo/resource_frame_buffer.go
@@ -23,10 +23,6 @@ type ResourceFrameBuffer struct {
 	Mode         uint16       `json:"mode"`
 }
 
-func (r ResourceFrameBuffer) ResourceType() ResourceType {
-	return ResourceTypeFramebuffer
-}
-
 func NewResourceFrameBuffer(res *C.hd_res_t, resType ResourceType) (*ResourceFrameBuffer, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -46,4 +42,8 @@ func NewResourceFrameBuffer(res *C.hd_res_t, resType ResourceType) (*ResourceFra
 		ColorBits:    uint16(fb.colorbits),
 		Mode:         uint16(fb.mode),
 	}, nil
+}
+
+func (r ResourceFrameBuffer) ResourceType() ResourceType {
+	return ResourceTypeFramebuffer
 }

--- a/pkg/hwinfo/resource_hw_addr.go
+++ b/pkg/hwinfo/resource_hw_addr.go
@@ -19,10 +19,6 @@ type ResourceHardwareAddress struct {
 	Address byte         `json:"address"`
 }
 
-func (r ResourceHardwareAddress) ResourceType() ResourceType {
-	return r.Type
-}
-
 func NewResourceHardwareAddress(res *C.hd_res_t, resType ResourceType) (*ResourceHardwareAddress, error) {
 	//nolint:staticcheck
 	if !(resType == ResourceTypeHwaddr || resType == ResourceTypePhwaddr) {
@@ -46,4 +42,8 @@ func NewResourceHardwareAddress(res *C.hd_res_t, resType ResourceType) (*Resourc
 		Type:    resType,
 		Address: address,
 	}, nil
+}
+
+func (r ResourceHardwareAddress) ResourceType() ResourceType {
+	return r.Type
 }

--- a/pkg/hwinfo/resource_init_strings.go
+++ b/pkg/hwinfo/resource_init_strings.go
@@ -20,10 +20,6 @@ type ResourceInitStrings struct {
 	Init2 string `json:"init_2,omitempty"`
 }
 
-func (r ResourceInitStrings) ResourceType() ResourceType {
-	return ResourceTypeInitStrings
-}
-
 func NewResourceInitStrings(res *C.hd_res_t, resType ResourceType) (*ResourceInitStrings, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -40,4 +36,8 @@ func NewResourceInitStrings(res *C.hd_res_t, resType ResourceType) (*ResourceIni
 		Init1: C.GoString(init.init1),
 		Init2: C.GoString(init.init2),
 	}, nil
+}
+
+func (r ResourceInitStrings) ResourceType() ResourceType {
+	return ResourceTypeInitStrings
 }

--- a/pkg/hwinfo/resource_io.go
+++ b/pkg/hwinfo/resource_io.go
@@ -27,10 +27,6 @@ type ResourceIO struct {
 	Access  AccessFlags  `json:"access"`
 }
 
-func (r ResourceIO) ResourceType() ResourceType {
-	return ResourceTypeIo
-}
-
 func NewResourceIO(res *C.hd_res_t, resType ResourceType) (*ResourceIO, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -49,4 +45,8 @@ func NewResourceIO(res *C.hd_res_t, resType ResourceType) (*ResourceIO, error) {
 		Enabled: bool(C.hd_res_io_get_enabled(io)),
 		Access:  AccessFlags(C.hd_res_io_get_access(io)),
 	}, nil
+}
+
+func (r ResourceIO) ResourceType() ResourceType {
+	return ResourceTypeIo
 }

--- a/pkg/hwinfo/resource_irq.go
+++ b/pkg/hwinfo/resource_irq.go
@@ -25,10 +25,6 @@ type ResourceIrq struct {
 	Enabled   bool         `json:"enabled"`
 }
 
-func (r ResourceIrq) ResourceType() ResourceType {
-	return ResourceTypeIrq
-}
-
 func NewResourceIrq(res *C.hd_res_t, resType ResourceType) (*ResourceIrq, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -46,4 +42,8 @@ func NewResourceIrq(res *C.hd_res_t, resType ResourceType) (*ResourceIrq, error)
 		Triggered: uint16(irq.triggered),
 		Enabled:   bool(C.hd_res_irq_get_enabled(irq)),
 	}, nil
+}
+
+func (r ResourceIrq) ResourceType() ResourceType {
+	return ResourceTypeIrq
 }

--- a/pkg/hwinfo/resource_link.go
+++ b/pkg/hwinfo/resource_link.go
@@ -23,10 +23,6 @@ type ResourceLink struct {
 	Connected bool         `json:"connected"`
 }
 
-func (r ResourceLink) ResourceType() ResourceType {
-	return ResourceTypeLink
-}
-
 func NewResourceLink(res *C.hd_res_t, resType ResourceType) (*ResourceLink, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -42,4 +38,8 @@ func NewResourceLink(res *C.hd_res_t, resType ResourceType) (*ResourceLink, erro
 		Type:      resType,
 		Connected: bool(C.hd_res_link_get_connected(link)),
 	}, nil
+}
+
+func (r ResourceLink) ResourceType() ResourceType {
+	return ResourceTypeLink
 }

--- a/pkg/hwinfo/resource_mem.go
+++ b/pkg/hwinfo/resource_mem.go
@@ -53,10 +53,6 @@ type ResourceMemory struct {
 	Prefetch YesNoFlags   `json:"prefetch"`
 }
 
-func (r ResourceMemory) ResourceType() ResourceType {
-	return ResourceTypeMem
-}
-
 func NewResourceMemory(res *C.hd_res_t, resType ResourceType) (*ResourceMemory, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -76,4 +72,8 @@ func NewResourceMemory(res *C.hd_res_t, resType ResourceType) (*ResourceMemory, 
 		Access:   AccessFlags(C.hd_res_mem_get_access(mem)),
 		Prefetch: YesNoFlags(C.hd_res_mem_get_prefetch(mem)),
 	}, nil
+}
+
+func (r ResourceMemory) ResourceType() ResourceType {
+	return ResourceTypeMem
 }

--- a/pkg/hwinfo/resource_monitor.go
+++ b/pkg/hwinfo/resource_monitor.go
@@ -26,10 +26,6 @@ type ResourceMonitor struct {
 	Interlaced        bool         `json:"interlaced"`
 }
 
-func (r ResourceMonitor) ResourceType() ResourceType {
-	return ResourceTypeMonitor
-}
-
 func NewResourceMonitor(res *C.hd_res_t, resType ResourceType) (*ResourceMonitor, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -48,4 +44,8 @@ func NewResourceMonitor(res *C.hd_res_t, resType ResourceType) (*ResourceMonitor
 		VerticalFrequency: uint16(monitor.vfreq),
 		Interlaced:        bool(C.hd_res_monitor_get_interlaced(monitor)),
 	}, nil
+}
+
+func (r ResourceMonitor) ResourceType() ResourceType {
+	return ResourceTypeMonitor
 }

--- a/pkg/hwinfo/resource_phys_mem.go
+++ b/pkg/hwinfo/resource_phys_mem.go
@@ -19,10 +19,6 @@ type ResourcePhysicalMemory struct {
 	Range uint64       `json:"range"`
 }
 
-func (r ResourcePhysicalMemory) ResourceType() ResourceType {
-	return ResourceTypePhysMem
-}
-
 func NewResourcePhysicalMemory(res *C.hd_res_t, resType ResourceType) (*ResourcePhysicalMemory, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -38,4 +34,8 @@ func NewResourcePhysicalMemory(res *C.hd_res_t, resType ResourceType) (*Resource
 		Type:  resType,
 		Range: uint64(physMem._range),
 	}, nil
+}
+
+func (r ResourcePhysicalMemory) ResourceType() ResourceType {
+	return ResourceTypePhysMem
 }

--- a/pkg/hwinfo/resource_pppd_option.go
+++ b/pkg/hwinfo/resource_pppd_option.go
@@ -19,10 +19,6 @@ type ResourcePppdOption struct {
 	Option byte         `json:"option"`
 }
 
-func (r ResourcePppdOption) ResourceType() ResourceType {
-	return ResourceTypePppdOption
-}
-
 func NewResourcePppdOption(res *C.hd_res_t, resType ResourceType) (*ResourcePppdOption, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -42,4 +38,8 @@ func NewResourcePppdOption(res *C.hd_res_t, resType ResourceType) (*ResourcePppd
 		Type:   resType,
 		Option: option,
 	}, nil
+}
+
+func (r ResourcePppdOption) ResourceType() ResourceType {
+	return ResourceTypePppdOption
 }

--- a/pkg/hwinfo/resource_size.go
+++ b/pkg/hwinfo/resource_size.go
@@ -37,10 +37,6 @@ type ResourceSize struct {
 	Value2 uint64       `json:"value_2,omitempty"`
 }
 
-func (r ResourceSize) ResourceType() ResourceType {
-	return ResourceTypeSize
-}
-
 func NewResourceSize(res *C.hd_res_t, resType ResourceType) (*ResourceSize, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -58,4 +54,8 @@ func NewResourceSize(res *C.hd_res_t, resType ResourceType) (*ResourceSize, erro
 		Value1: uint64(size.val1),
 		Value2: uint64(size.val2),
 	}, nil
+}
+
+func (r ResourceSize) ResourceType() ResourceType {
+	return ResourceTypeSize
 }

--- a/pkg/hwinfo/resource_wlan.go
+++ b/pkg/hwinfo/resource_wlan.go
@@ -23,10 +23,6 @@ type ResourceWlan struct {
 	EncModes    []string     `json:"enc_modes,omitempty"`
 }
 
-func (r ResourceWlan) ResourceType() ResourceType {
-	return ResourceTypeWlan
-}
-
 func NewResourceWlan(res *C.hd_res_t, resType ResourceType) (*ResourceWlan, error) {
 	if res == nil {
 		return nil, errors.New("res is nil")
@@ -46,4 +42,8 @@ func NewResourceWlan(res *C.hd_res_t, resType ResourceType) (*ResourceWlan, erro
 		AuthModes:   ReadStringList(wlan.auth_modes),
 		EncModes:    ReadStringList(wlan.enc_modes),
 	}, nil
+}
+
+func (r ResourceWlan) ResourceType() ResourceType {
+	return ResourceTypeWlan
 }

--- a/pkg/hwinfo/smbios.go
+++ b/pkg/hwinfo/smbios.go
@@ -95,7 +95,9 @@ const (
 	SmbiosTypeTPM
 	SmbiosTypeProcessorAdditional
 	SmbiosTypeFirmwareInventory
+)
 
+const (
 	SmbiosTypeInactive   SmbiosType = 126
 	SmbiosTypeEndOfTable SmbiosType = 127
 )

--- a/pkg/hwinfo/smbios_any.go
+++ b/pkg/hwinfo/smbios_any.go
@@ -19,10 +19,6 @@ type SmbiosAny struct {
 	Strings []string   `json:"strings,omitempty"`
 }
 
-func (s SmbiosAny) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosAny(smbiosType SmbiosType, info C.smbios_any_t) (*SmbiosAny, error) {
 	return &SmbiosAny{
 		Type:    smbiosType,
@@ -30,4 +26,8 @@ func NewSmbiosAny(smbiosType SmbiosType, info C.smbios_any_t) (*SmbiosAny, error
 		Data:    fmt.Sprintf("0x%x", ReadByteArray(unsafe.Pointer(info.data), int(info.data_len))),
 		Strings: ReadStringList(info.strings),
 	}, nil
+}
+
+func (s SmbiosAny) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_bios.go
+++ b/pkg/hwinfo/smbios_bios.go
@@ -22,10 +22,6 @@ type SmbiosBios struct {
 	RomSize      uint32     `json:"rom_size"`
 }
 
-func (s SmbiosBios) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosBiosInfo(info C.smbios_biosinfo_t) (*SmbiosBios, error) {
 	return &SmbiosBios{
 		Type:         SmbiosTypeBios,
@@ -37,4 +33,8 @@ func NewSmbiosBiosInfo(info C.smbios_biosinfo_t) (*SmbiosBios, error) {
 		StartAddress: fmt.Sprintf("0x%x", uint(info.start)),
 		RomSize:      uint32(info.rom_size),
 	}, nil
+}
+
+func (s SmbiosBios) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_board.go
+++ b/pkg/hwinfo/smbios_board.go
@@ -23,10 +23,6 @@ type SmbiosBoard struct {
 	Objects      []int      `json:"objects,omitempty"` // array of object handles
 }
 
-func (s SmbiosBoard) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosBoardInfo(info C.smbios_boardinfo_t) (*SmbiosBoard, error) {
 	return &SmbiosBoard{
 		Type:         SmbiosTypeBoard,
@@ -42,4 +38,8 @@ func NewSmbiosBoardInfo(info C.smbios_boardinfo_t) (*SmbiosBoard, error) {
 		Chassis:      int(info.chassis),
 		Objects:      ReadIntArray(unsafe.Pointer(info.objects), int(info.objects_len)),
 	}, nil
+}
+
+func (s SmbiosBoard) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_cache.go
+++ b/pkg/hwinfo/smbios_cache.go
@@ -26,10 +26,6 @@ type SmbiosCache struct {
 	SRAMTypes     []string   `json:"sram_type_supported"`
 }
 
-func (s SmbiosCache) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosCache(info C.smbios_cache_t) (*SmbiosCache, error) {
 	return &SmbiosCache{
 		Type:          SmbiosTypeCache,
@@ -49,4 +45,8 @@ func NewSmbiosCache(info C.smbios_cache_t) (*SmbiosCache, error) {
 		SRAMType:      ReadStringList(info.sram.str),
 		SRAMTypes:     ReadStringList(info.supp_sram.str),
 	}, nil
+}
+
+func (s SmbiosCache) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_chassis.go
+++ b/pkg/hwinfo/smbios_chassis.go
@@ -24,10 +24,6 @@ type SmbiosChassis struct {
 	OEM           string     `json:"oem"`            // oem-specific information"
 }
 
-func (s SmbiosChassis) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosChassis(info C.smbios_chassis_t) (*SmbiosChassis, error) {
 	return &SmbiosChassis{
 		Type:          SmbiosTypeChassis,
@@ -44,4 +40,8 @@ func NewSmbiosChassis(info C.smbios_chassis_t) (*SmbiosChassis, error) {
 		SecurityState: NewID(info.security),
 		OEM:           fmt.Sprintf("0x%x", uint(info.oem)),
 	}, nil
+}
+
+func (s SmbiosChassis) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_config.go
+++ b/pkg/hwinfo/smbios_config.go
@@ -13,14 +13,14 @@ type SmbiosConfig struct {
 	Options []string   `json:"options,omitempty"`
 }
 
-func (s SmbiosConfig) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosConfig(info C.smbios_config_t) (*SmbiosConfig, error) {
 	return &SmbiosConfig{
 		Type:    SmbiosTypeConfig,
 		Handle:  int(info.handle),
 		Options: ReadStringList(info.options),
 	}, nil
+}
+
+func (s SmbiosConfig) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_group_associations.go
+++ b/pkg/hwinfo/smbios_group_associations.go
@@ -15,10 +15,6 @@ type SmbiosGroupAssociations struct {
 	Handles []int      `json:"handles,omitempty"` // array of item handles
 }
 
-func (s SmbiosGroupAssociations) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosGroup(info C.smbios_group_t) (*SmbiosGroupAssociations, error) {
 	return &SmbiosGroupAssociations{
 		Type:    SmbiosTypeGroupAssociations,
@@ -26,4 +22,8 @@ func NewSmbiosGroup(info C.smbios_group_t) (*SmbiosGroupAssociations, error) {
 		Name:    C.GoString(info.name),
 		Handles: ReadIntArray(unsafe.Pointer(info.item_handles), int(info.items_len)),
 	}, nil
+}
+
+func (s SmbiosGroupAssociations) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_hardware_security.go
+++ b/pkg/hwinfo/smbios_hardware_security.go
@@ -16,10 +16,6 @@ type SmbiosHardwareSecurity struct {
 	Reset    *ID        `json:"reset"`    // front panel reset status
 }
 
-func (s SmbiosHardwareSecurity) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosSecure(info C.smbios_secure_t) (*SmbiosHardwareSecurity, error) {
 	return &SmbiosHardwareSecurity{
 		Type:     SmbiosTypeHardwareSecurity,
@@ -29,4 +25,8 @@ func NewSmbiosSecure(info C.smbios_secure_t) (*SmbiosHardwareSecurity, error) {
 		Admin:    NewID(info.admin),
 		Reset:    NewID(info.reset),
 	}, nil
+}
+
+func (s SmbiosHardwareSecurity) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_language.go
+++ b/pkg/hwinfo/smbios_language.go
@@ -14,10 +14,6 @@ type SmbiosLanguage struct {
 	CurrentLanguage string     `json:"-"`
 }
 
-func (s SmbiosLanguage) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosLang(info C.smbios_lang_t) (*SmbiosLanguage, error) {
 	return &SmbiosLanguage{
 		Type:            SmbiosTypeLanguage,
@@ -25,4 +21,8 @@ func NewSmbiosLang(info C.smbios_lang_t) (*SmbiosLanguage, error) {
 		Languages:       ReadStringList(info.strings),
 		CurrentLanguage: C.GoString(info.current),
 	}, nil
+}
+
+func (s SmbiosLanguage) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_memory64_error.go
+++ b/pkg/hwinfo/smbios_memory64_error.go
@@ -20,10 +20,6 @@ type SmbiosMemory64Error struct {
 	Range         uint32     `json:"range"`          // range within which the error can be determined; 0x80000000: unknown
 }
 
-func (s SmbiosMemory64Error) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMem64Error(info C.smbios_mem64error_t) (*SmbiosMemory64Error, error) {
 	return &SmbiosMemory64Error{
 		Type:          SmbiosTypeMemory64Error,
@@ -36,4 +32,8 @@ func NewSmbiosMem64Error(info C.smbios_mem64error_t) (*SmbiosMemory64Error, erro
 		DeviceAddress: fmt.Sprintf("0x%x", uint(info.device_addr)),
 		Range:         uint32(info._range),
 	}, nil
+}
+
+func (s SmbiosMemory64Error) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_memory_array.go
+++ b/pkg/hwinfo/smbios_memory_array.go
@@ -19,10 +19,6 @@ type SmbiosMemoryArray struct {
 	Slots       uint16     `json:"slots"`        // slots or sockets for this device
 }
 
-func (s SmbiosMemoryArray) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMemArray(info C.smbios_memarray_t) (*SmbiosMemoryArray, error) {
 	return &SmbiosMemoryArray{
 		Type:        SmbiosTypeMemoryArray,
@@ -34,4 +30,8 @@ func NewSmbiosMemArray(info C.smbios_memarray_t) (*SmbiosMemoryArray, error) {
 		ErrorHandle: int(info.error_handle),
 		Slots:       uint16(info.slots),
 	}, nil
+}
+
+func (s SmbiosMemoryArray) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_memory_array_mapped_address.go
+++ b/pkg/hwinfo/smbios_memory_array_mapped_address.go
@@ -17,10 +17,6 @@ type SmbiosMemoryArrayMappedAddress struct {
 	PartWidth    uint16     `json:"part_width"`    // number of memory devices
 }
 
-func (s SmbiosMemoryArrayMappedAddress) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMemArrayMap(info C.smbios_memarraymap_t) (*SmbiosMemoryArrayMappedAddress, error) {
 	return &SmbiosMemoryArrayMappedAddress{
 		Type:         SmbiosTypeMemoryArrayMappedAddress,
@@ -30,4 +26,8 @@ func NewSmbiosMemArrayMap(info C.smbios_memarraymap_t) (*SmbiosMemoryArrayMapped
 		EndAddress:   fmt.Sprintf("0x%x", uint64(info.end_addr)),
 		PartWidth:    uint16(info.part_width),
 	}, nil
+}
+
+func (s SmbiosMemoryArrayMappedAddress) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_memory_device.go
+++ b/pkg/hwinfo/smbios_memory_device.go
@@ -30,10 +30,6 @@ type SmbiosMemoryDevice struct {
 	Speed             uint32     `json:"speed"` // MHz
 }
 
-func (s SmbiosMemoryDevice) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMemDevice(info C.smbios_memdevice_t) (*SmbiosMemoryDevice, error) {
 	return &SmbiosMemoryDevice{
 		Type:              SmbiosTypeMemoryDevice,
@@ -55,4 +51,8 @@ func NewSmbiosMemDevice(info C.smbios_memdevice_t) (*SmbiosMemoryDevice, error) 
 		MemoryTypeDetails: ReadStringList(info.type_detail.str),
 		Speed:             uint32(info.speed),
 	}, nil
+}
+
+func (s SmbiosMemoryDevice) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_memory_device_mapped_address.go
+++ b/pkg/hwinfo/smbios_memory_device_mapped_address.go
@@ -22,10 +22,6 @@ type SmbiosMemoryDeviceMappedAddress struct {
 	InterleaveDepth    uint16     `json:"interleave_depth"`    // number of consecutive rows
 }
 
-func (s SmbiosMemoryDeviceMappedAddress) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMemDeviceMap(info C.smbios_memdevicemap_t) (*SmbiosMemoryDeviceMappedAddress, error) {
 	return &SmbiosMemoryDeviceMappedAddress{
 		Type:               SmbiosTypeMemoryDeviceMappedAddress,
@@ -38,4 +34,8 @@ func NewSmbiosMemDeviceMap(info C.smbios_memdevicemap_t) (*SmbiosMemoryDeviceMap
 		InterleavePosition: uint16(info.interleave_pos),
 		InterleaveDepth:    uint16(info.interleave_depth),
 	}, nil
+}
+
+func (s SmbiosMemoryDeviceMappedAddress) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_memory_error.go
+++ b/pkg/hwinfo/smbios_memory_error.go
@@ -20,10 +20,6 @@ type SmbiosMemoryError struct {
 	Range         uint32     `json:"range"`          // range within which the error can be determined; 0x80000000: unknown
 }
 
-func (s SmbiosMemoryError) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMemError(info C.smbios_memerror_t) (*SmbiosMemoryError, error) {
 	return &SmbiosMemoryError{
 		Type:          SmbiosTypeMemoryError,
@@ -36,4 +32,8 @@ func NewSmbiosMemError(info C.smbios_memerror_t) (*SmbiosMemoryError, error) {
 		DeviceAddress: fmt.Sprintf("0x%x", uint(info.device_addr)),
 		Range:         uint32(info._range),
 	}, nil
+}
+
+func (s SmbiosMemoryError) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_oem_strings.go
+++ b/pkg/hwinfo/smbios_oem_strings.go
@@ -13,14 +13,14 @@ type SmbiosOEMStrings struct {
 	Strings []string   `json:"strings,omitempty"`
 }
 
-func (s SmbiosOEMStrings) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosOEM(info C.smbios_oem_t) (*SmbiosOEMStrings, error) {
 	return &SmbiosOEMStrings{
 		Type:    SmbiosTypeOEMStrings,
 		Handle:  int(info.handle),
 		Strings: ReadStringList(info.oem_strings),
 	}, nil
+}
+
+func (s SmbiosOEMStrings) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_onboard.go
+++ b/pkg/hwinfo/smbios_onboard.go
@@ -23,10 +23,6 @@ type SmbiosOnboard struct {
 	Devices []OnboardDevice `json:"devices,omitempty"`
 }
 
-func (s SmbiosOnboard) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosOnboard(info C.smbios_onboard_t) (*SmbiosOnboard, error) {
 	count := int(info.dev_len)
 	devices := make([]OnboardDevice, 0, count)
@@ -44,4 +40,8 @@ func NewSmbiosOnboard(info C.smbios_onboard_t) (*SmbiosOnboard, error) {
 		Handle:  int(info.handle),
 		Devices: devices,
 	}, nil
+}
+
+func (s SmbiosOnboard) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_pointing_device.go
+++ b/pkg/hwinfo/smbios_pointing_device.go
@@ -15,10 +15,6 @@ type SmbiosPointingDevice struct {
 	Buttons   uint16     `json:"buttons"`
 }
 
-func (s SmbiosPointingDevice) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosMouse(info C.smbios_mouse_t) (*SmbiosPointingDevice, error) {
 	return &SmbiosPointingDevice{
 		Type:      SmbiosTypePointingDevice,
@@ -27,4 +23,8 @@ func NewSmbiosMouse(info C.smbios_mouse_t) (*SmbiosPointingDevice, error) {
 		Interface: NewID(info._interface),
 		Buttons:   uint16(info.buttons),
 	}, nil
+}
+
+func (s SmbiosPointingDevice) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_port_connector.go
+++ b/pkg/hwinfo/smbios_port_connector.go
@@ -17,10 +17,6 @@ type SmbiosPortConnector struct {
 	ExternalReferenceDesignator string     `json:"external_reference_designator,omitempty"`
 }
 
-func (s SmbiosPortConnector) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosConnect(info C.smbios_connect_t) (*SmbiosPortConnector, error) {
 	return &SmbiosPortConnector{
 		Type:                        SmbiosTypePortConnector,
@@ -31,4 +27,8 @@ func NewSmbiosConnect(info C.smbios_connect_t) (*SmbiosPortConnector, error) {
 		ExternalConnectorType:       NewID(info.x_type),
 		ExternalReferenceDesignator: C.GoString(info.x_des),
 	}, nil
+}
+
+func (s SmbiosPortConnector) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_power_controls.go
+++ b/pkg/hwinfo/smbios_power_controls.go
@@ -17,10 +17,6 @@ type SmbiosPowerControls struct {
 	Second uint8      `json:"second"` // dto, second
 }
 
-func (s SmbiosPowerControls) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosPower(info C.smbios_power_t) (*SmbiosPowerControls, error) {
 	return &SmbiosPowerControls{
 		Type:   SmbiosTypePowerControls,
@@ -31,4 +27,8 @@ func NewSmbiosPower(info C.smbios_power_t) (*SmbiosPowerControls, error) {
 		Minute: uint8(info.minute),
 		Second: uint8(info.second),
 	}, nil
+}
+
+func (s SmbiosPowerControls) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_processor.go
+++ b/pkg/hwinfo/smbios_processor.go
@@ -31,10 +31,6 @@ type SmbiosProcessor struct {
 	CacheHandleL3   int        `json:"cache_handle_l3"` // handle of L3 cache
 }
 
-func (s SmbiosProcessor) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosProcessor(info C.smbios_processor_t) (*SmbiosProcessor, error) {
 	return &SmbiosProcessor{
 		Type:            SmbiosTypeProcessor,
@@ -59,4 +55,8 @@ func NewSmbiosProcessor(info C.smbios_processor_t) (*SmbiosProcessor, error) {
 		CacheHandleL2:   int(info.l2_cache),
 		CacheHandleL3:   int(info.l3_cache),
 	}, nil
+}
+
+func (s SmbiosProcessor) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_slot.go
+++ b/pkg/hwinfo/smbios_slot.go
@@ -19,10 +19,6 @@ type SmbiosSlot struct {
 	Features    []string   `json:"features,omitempty"`
 }
 
-func (s SmbiosSlot) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosSlot(info C.smbios_slot_t) (*SmbiosSlot, error) {
 	return &SmbiosSlot{
 		Type:        SmbiosTypeSlot,
@@ -35,4 +31,8 @@ func NewSmbiosSlot(info C.smbios_slot_t) (*SmbiosSlot, error) {
 		ID:          uint16(info.id),
 		Features:    ReadStringList(info.feature.str),
 	}, nil
+}
+
+func (s SmbiosSlot) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/smbios_sys_info.go
+++ b/pkg/hwinfo/smbios_sys_info.go
@@ -18,10 +18,6 @@ type SmbiosSystem struct {
 	WakeUp       *ID        `json:"wake_up"` // wake-up type
 }
 
-func (s SmbiosSystem) SmbiosType() SmbiosType {
-	return s.Type
-}
-
 func NewSmbiosSysInfo(info C.smbios_sysinfo_t) (*SmbiosSystem, error) {
 	return &SmbiosSystem{
 		Type:         SmbiosTypeSystem,
@@ -33,4 +29,8 @@ func NewSmbiosSysInfo(info C.smbios_sysinfo_t) (*SmbiosSystem, error) {
 		// todo uuid
 		WakeUp: NewID(info.wake_up),
 	}, nil
+}
+
+func (s SmbiosSystem) SmbiosType() SmbiosType {
+	return s.Type
 }

--- a/pkg/hwinfo/utils.go
+++ b/pkg/hwinfo/utils.go
@@ -5,7 +5,11 @@ package hwinfo
 #include <hd.h>
 */
 import "C"
-import "unsafe"
+
+import (
+	"slices"
+	"unsafe"
+)
 
 func ReadStringList(list *C.str_list_t) []string {
 	var result []string
@@ -16,67 +20,48 @@ func ReadStringList(list *C.str_list_t) []string {
 	return result
 }
 
+// ReadUint64Array copies a C uint64_t array into a Go slice.
 func ReadUint64Array(arr unsafe.Pointer, length int) []uint64 {
 	if arr == nil || length <= 0 {
 		return nil
 	}
 
-	start := uintptr(arr)
-
-	result := make([]uint64, length)
-	for i := range result {
-		next := start + uintptr(i*C.sizeof_uint64_t)
-		result[i] = *(*uint64)(unsafe.Pointer(next)) //nolint:govet
-	}
-
-	return result
+	return slices.Clone(unsafe.Slice((*uint64)(arr), length))
 }
 
+// ReadUintArray copies a C unsigned array into a Go slice.
 func ReadUintArray(arr unsafe.Pointer, length int) []uint {
 	if arr == nil || length <= 0 {
 		return nil
 	}
 
-	start := uintptr(arr)
-
 	result := make([]uint, length)
-	for i := range result {
-		next := start + uintptr(i*C.sizeof_uint)
-		result[i] = *(*uint)(unsafe.Pointer(next)) //nolint:govet
+	for i, v := range unsafe.Slice((*C.uint)(arr), length) {
+		result[i] = uint(v)
 	}
 
 	return result
 }
 
+// ReadIntArray copies a C int array into a Go slice.
 func ReadIntArray(arr unsafe.Pointer, length int) []int {
-	// TODO see if we can use generics to combine some of these methods
 	if arr == nil || length <= 0 {
 		return nil
 	}
 
-	start := uintptr(arr)
-
 	result := make([]int, length)
-	for i := range result {
-		next := start + uintptr(i*C.sizeof_uint)
-		result[i] = *(*int)(unsafe.Pointer(next)) //nolint:govet
+	for i, v := range unsafe.Slice((*C.int)(arr), length) {
+		result[i] = int(v)
 	}
 
 	return result
 }
 
+// ReadByteArray copies a C unsigned char array into a Go slice.
 func ReadByteArray(arr unsafe.Pointer, length int) []byte {
 	if arr == nil || length <= 0 {
 		return nil
 	}
 
-	start := uintptr(arr)
-
-	result := make([]byte, length)
-	for i := range result {
-		next := start + uintptr(i*C.sizeof_uint)
-		result[i] = *(*byte)(unsafe.Pointer(next)) //nolint:govet
-	}
-
-	return result
+	return slices.Clone(unsafe.Slice((*byte)(arr), length))
 }

--- a/pkg/hwinfo/utils_test.go
+++ b/pkg/hwinfo/utils_test.go
@@ -1,0 +1,59 @@
+//nolint:gosec
+package hwinfo_test
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/numtide/nixos-facter/pkg/hwinfo"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests lay out buffers exactly as the C structs do (unsigned char *,
+// int *, unsigned *, uint64_t *) and verify the readers decode them
+// element-for-element.
+
+func TestReadUint64Array(t *testing.T) {
+	t.Parallel()
+
+	src := []uint64{0xdeadbeefcafebabe, 1, 0, 42}
+	got := hwinfo.ReadUint64Array(unsafe.Pointer(&src[0]), len(src))
+	require.Equal(t, src, got)
+
+	require.Nil(t, hwinfo.ReadUint64Array(nil, 4))
+	require.Nil(t, hwinfo.ReadUint64Array(unsafe.Pointer(&src[0]), 0))
+}
+
+func TestReadUintArray(t *testing.T) {
+	t.Parallel()
+
+	// C `unsigned` is 32-bit on all supported platforms.
+	src := []uint32{0xffffffff, 0, 1, 7}
+	got := hwinfo.ReadUintArray(unsafe.Pointer(&src[0]), len(src))
+	require.Equal(t, []uint{0xffffffff, 0, 1, 7}, got)
+
+	require.Nil(t, hwinfo.ReadUintArray(nil, 4))
+	require.Nil(t, hwinfo.ReadUintArray(unsafe.Pointer(&src[0]), -1))
+}
+
+func TestReadIntArray(t *testing.T) {
+	t.Parallel()
+
+	// C `int` is 32-bit; adjacent non-zero elements catch 8-byte over-reads.
+	src := []int32{1, 2, 3, -4}
+	got := hwinfo.ReadIntArray(unsafe.Pointer(&src[0]), len(src))
+	require.Equal(t, []int{1, 2, 3, -4}, got)
+
+	require.Nil(t, hwinfo.ReadIntArray(nil, 4))
+}
+
+func TestReadByteArray(t *testing.T) {
+	t.Parallel()
+
+	// C `unsigned char` is 1 byte; distinct values catch 4-byte strides.
+	src := []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+	got := hwinfo.ReadByteArray(unsafe.Pointer(&src[0]), len(src))
+	require.Equal(t, src, got)
+
+	require.Nil(t, hwinfo.ReadByteArray(nil, 4))
+}

--- a/pkg/linux/input/input.go
+++ b/pkg/linux/input/input.go
@@ -132,7 +132,8 @@ func ReadDevices(r io.ReadCloser) ([]*Device, error) {
 
 		switch line[:3] {
 		case "I: ":
-			if err := readBasicInfo(line, device); err != nil {
+			err := readBasicInfo(line, device)
+			if err != nil {
 				return nil, fmt.Errorf("failed to read basic info: %w", err)
 			}
 		case "N: ":

--- a/pkg/linux/input/input_test.go
+++ b/pkg/linux/input/input_test.go
@@ -11,6 +11,14 @@ import (
 )
 
 const (
+	handlerKbd = "kbd"
+
+	capProp = "PROP"
+	capKey  = "KEY"
+	capMsc  = "MSC"
+)
+
+const (
 	devices = `I: Bus=0003 Vendor=1038 Product=1634 Version=0111
 N: Name="SteelSeries SteelSeries Apex 9 TKL"
 P: Phys=usb-0000:08:00.3-2.4.2/input2
@@ -69,13 +77,13 @@ func TestReadDevices(t *testing.T) {
 			Name:     "SteelSeries SteelSeries Apex 9 TKL", //nolint:dupword
 			Phys:     "usb-0000:08:00.3-2.4.2/input2",
 			Sysfs:    "/devices/pci0000:00/0000:00:01.2/0000:02:00.0/0000:03:08.0/0000:08:00.3/usb3/3-2/3-2.4/3-2.4.2/3-2.4.2:1.2/0003:1038:1634.000B/input/input11",
-			Handlers: []string{"sysrq", "kbd", "leds", "event4"},
+			Handlers: []string{"sysrq", handlerKbd, "leds", "event4"},
 			Capabilities: map[string]string{
-				"PROP": "0",
-				"EV":   "120013",
-				"KEY":  "1000000000007 ff9f207ac14057ff febeffdfffefffff fffffffffffffffe",
-				"MSC":  "10",
-				"LED":  "7",
+				capProp: "0",
+				"EV":    "120013",
+				capKey:  "1000000000007 ff9f207ac14057ff febeffdfffefffff fffffffffffffffe",
+				capMsc:  "10",
+				"LED":   "7",
 			},
 		},
 		{
@@ -86,15 +94,15 @@ func TestReadDevices(t *testing.T) {
 			Name:     "Logitech MX Vertical",
 			Phys:     "usb-0000:08:00.3-2.2/input2:1",
 			Sysfs:    "/devices/pci0000:00/0000:00:01.2/0000:02:00.0/0000:03:08.0/0000:08:00.3/usb3/3-2/3-2.2/3-2.2:1.2/0003:046D:C52B.0004/0003:046D:407B.0005/input/input8",
-			Handlers: []string{"sysrq", "kbd", "leds", "event1", "mouse0"},
+			Handlers: []string{"sysrq", handlerKbd, "leds", "event1", "mouse0"},
 			Capabilities: map[string]string{
-				"PROP": "0",
-				"EV":   "12001f",
-				"KEY":  "3f00033fff 0 0 483ffff17aff32d bfd4444600000000 ffff0001 130ff38b17d007 ffff7bfad9415fff ffbeffdfffefffff fffffffffffffffe",
-				"REL":  "1943",
-				"ABS":  "100000000",
-				"MSC":  "10",
-				"LED":  "1f",
+				capProp: "0",
+				"EV":    "12001f",
+				capKey:  "3f00033fff 0 0 483ffff17aff32d bfd4444600000000 ffff0001 130ff38b17d007 ffff7bfad9415fff ffbeffdfffefffff fffffffffffffffe",
+				"REL":   "1943",
+				"ABS":   "100000000",
+				capMsc:  "10",
+				"LED":   "1f",
 			},
 		},
 		{
@@ -105,13 +113,13 @@ func TestReadDevices(t *testing.T) {
 			Name:     "Blue Microphones Yeti Stereo Microphone Consumer Control",
 			Phys:     "usb-0000:0f:00.3-4/input3",
 			Sysfs:    "/devices/pci0000:00/0000:00:08.1/0000:0f:00.3/usb5/5-4/5-4:1.3/0003:B58E:9E84.0001/input/input0",
-			Handlers: []string{"kbd", "event0"},
+			Handlers: []string{handlerKbd, "event0"},
 			Capabilities: map[string]string{
-				"PROP": "0",
-				"EV":   "1b",
-				"KEY":  "1 0 7800000000 e000000000000 0",
-				"ABS":  "10000000000",
-				"MSC":  "10",
+				capProp: "0",
+				"EV":    "1b",
+				capKey:  "1 0 7800000000 e000000000000 0",
+				"ABS":   "10000000000",
+				capMsc:  "10",
 			},
 		},
 	}

--- a/pkg/udev/udev.go
+++ b/pkg/udev/udev.go
@@ -47,6 +47,7 @@ struct kv_pair *facter_udev_get_device_properties(struct udev_device *device, si
 import "C"
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -244,17 +245,21 @@ func NewUdev(env map[string]string) (*Udev, error) {
 	// ID_BUS is set by systemd-udev rules and has an open-ended value space
 	// (usb, pci, scsi, ata, acpi, platform, virtio, ...); only dispatch on
 	// the buses we have parsers for. See issue #554.
-	var err error
-
 	switch env["ID_BUS"] {
 	case "usb":
-		if result.Usb, err = NewUdevUsb(env); err != nil {
+		usb, err := NewUdevUsb(env)
+		if err != nil {
 			return nil, fmt.Errorf("failed to parse usb: %w", err)
 		}
+
+		result.Usb = usb
 	case "pci":
-		if result.Pci, err = NewUdevPci(env); err != nil {
+		pci, err := NewUdevPci(env)
+		if err != nil {
 			return nil, fmt.Errorf("failed to parse pci: %w", err)
 		}
+
+		result.Pci = pci
 	}
 
 	return result, nil
@@ -305,7 +310,7 @@ func Read(sysPath string) (*Udev, error) {
 // Version retrieves the systemd major version by executing the "udevadm --version" command and parsing its output.
 // It returns the parsed version as an uint64, or an error if the command execution or parsing fails.
 func Version() (uint64, error) {
-	cmd := exec.Command("udevadm", "--version")
+	cmd := exec.CommandContext(context.Background(), "udevadm", "--version")
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/pkg/virt/virt.go
+++ b/pkg/virt/virt.go
@@ -5,6 +5,8 @@
 package virt
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -53,13 +55,18 @@ const (
 // Detect identifies the virtualisation type of the current system.
 // Returns the detected Type and an error if detection fails.
 func Detect() (Type, error) {
-	path, err := exec.LookPath("systemd-detect-virt")
-	if err != nil {
+	_, err := exec.LookPath("systemd-detect-virt")
+	if errors.Is(err, exec.ErrNotFound) {
 		slog.Warn("systemd-detect-virt not found, skipping virtualisation detection")
+
 		return TypeNone, nil
 	}
 
-	out, err := exec.Command(path).CombinedOutput()
+	if err != nil {
+		return TypeNone, fmt.Errorf("failed to locate systemd-detect-virt: %w", err)
+	}
+
+	out, err := exec.CommandContext(context.Background(), "systemd-detect-virt").CombinedOutput()
 	outStr := strings.Trim(string(out), "\n")
 
 	// note: systemd-detect-virt exits with status 1 when "none" is detected


### PR DESCRIPTION
* update flake inputs
* migrate Go 1.25 -> Go 1.26
* fix applying `golangci-lint` during package build and address the issues it flagged
* fix reading of C arrays, which was caught during the upgrade. Affects fields that are typically not used or read by anyone, but they will need to be flagged during the next release, as they will cause a report change.