### PR TITLE
Minor tweaks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,7 @@ linters:
         - gochecknoglobals
         - wsl
         - gomodguard
+        - noinlineerr
 
     settings:
         cyclop:

--- a/nix/packages/nixos-facter/package.nix
+++ b/nix/packages/nixos-facter/package.nix
@@ -14,7 +14,7 @@ let
 in
 buildGo126Module (final: {
   pname = "nixos-facter";
-  version = "0.4.4";
+  version = "0.4.5+dev";
 
   src = fs.toSource {
     root = ../../..;


### PR DESCRIPTION
* disable `noinlineerr` in `golangci-lint` as I feel inline errors are idiomatic Go
* bump nix package version to `0.4.5+dev` as it was set at `0.4.4` which is the latest release