### PR TITLE
facter: don't index CPU list by physical id

### DIFF
--- a/pkg/facter/hardware.go
+++ b/pkg/facter/hardware.go
@@ -242,41 +242,31 @@ func (h *Hardware) add(device hwinfo.HardwareDevice) error {
 		h.ChipCard = append(h.ChipCard, device)
 		slices.SortFunc(h.ChipCard, compareDevice)
 	case hwinfo.HardwareClassCpu:
-		if device.Detail == nil {
+		cpu, ok := device.Detail.(*hwinfo.DetailCPU)
+		if device.Detail != nil && !ok {
+			return fmt.Errorf("expected hwinfo.DetailCPU, found %T", device.Detail)
+		}
+
+		if cpu == nil {
 			// CPU detail data unavailable (can happen on some hypervisors)
 			return nil
 		}
 
-		cpu, ok := device.Detail.(*hwinfo.DetailCPU)
-		if !ok {
-			return fmt.Errorf("expected hwinfo.DetailCPU, found %T", device.Detail)
+		// We only want one entry per physical id. Physical ids can be sparse (e.g. VMware
+		// assigns ids 0, 2, 4, ... with one core per socket), so we shouldn't index the slice
+		// by physical id. This avoids nil holes which serialise as null in the report.
+		idx := slices.IndexFunc(h.CPU, func(c *hwinfo.DetailCPU) bool {
+			return c.PhysicalID == cpu.PhysicalID
+		})
+		if idx >= 0 {
+			h.CPU[idx] = cpu
+		} else {
+			h.CPU = append(h.CPU, cpu)
 		}
 
-		// We insert by physical id, as we only want one entry per core.
-		requiredSize := int(cpu.PhysicalID) + 1
-
-		if len(h.CPU) < requiredSize {
-			newItems := make([]*hwinfo.DetailCPU, requiredSize-len(h.CPU))
-			h.CPU = append(h.CPU, newItems...)
-		}
-
-		// add our new entry
-		h.CPU[cpu.PhysicalID] = cpu
-
-		// Sort in ascending order to ensure a stable output.
-		// It's possible that the CPU list contains nil pointers as we are not guaranteed to read the CPU's in order of
-		// physical id.
+		// Sort by physical id in ascending order to ensure a stable output.
 		slices.SortFunc(h.CPU, func(a, b *hwinfo.DetailCPU) int {
-			switch {
-			case a == nil && b == nil:
-				return 0
-			case a == nil && b != nil:
-				return -1
-			case a != nil && b == nil:
-				return 1
-			default:
-				return int(a.PhysicalID - b.PhysicalID)
-			}
+			return int(a.PhysicalID) - int(b.PhysicalID)
 		})
 
 	case hwinfo.HardwareClassDisk:

--- a/pkg/facter/hardware_test.go
+++ b/pkg/facter/hardware_test.go
@@ -1,0 +1,80 @@
+//nolint:testpackage
+package facter
+
+import (
+	"testing"
+
+	"github.com/numtide/nixos-facter/pkg/hwinfo"
+)
+
+func cpuDevice(physicalID uint16) hwinfo.HardwareDevice {
+	return hwinfo.HardwareDevice{
+		Class:  hwinfo.HardwareClassCpu,
+		Detail: &hwinfo.DetailCPU{PhysicalID: physicalID},
+	}
+}
+
+// Regression test for https://github.com/nix-community/nixos-facter/issues/276:
+// sparse physical ids (e.g. VMware with one core per socket assigns ids 0, 2, 4, ...)
+// must not leave nil holes in Hardware.CPU, which serialise as null in the report.
+func TestHardwareAddCPUSparsePhysicalIDs(t *testing.T) {
+	t.Parallel()
+
+	var h Hardware
+
+	for _, id := range []uint16{4, 0, 2} {
+		if err := h.add(cpuDevice(id)); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+
+	if len(h.CPU) != 3 {
+		t.Fatalf("expected 3 cpu entries, got %d", len(h.CPU))
+	}
+
+	for i, want := range []uint16{0, 2, 4} {
+		if h.CPU[i] == nil {
+			t.Fatalf("cpu entry %d is nil", i)
+		}
+
+		if h.CPU[i].PhysicalID != want {
+			t.Fatalf("cpu entry %d: expected physical id %d, got %d", i, want, h.CPU[i].PhysicalID)
+		}
+	}
+}
+
+// One entry per physical id: sibling logical processors must not duplicate sockets.
+func TestHardwareAddCPUDeduplicatesPhysicalID(t *testing.T) {
+	t.Parallel()
+
+	var h Hardware
+
+	for _, id := range []uint16{0, 0, 1, 1} {
+		if err := h.add(cpuDevice(id)); err != nil {
+			t.Fatalf("add: %v", err)
+		}
+	}
+
+	if len(h.CPU) != 2 {
+		t.Fatalf("expected 2 cpu entries, got %d", len(h.CPU))
+	}
+}
+
+// CPU devices with unavailable detail data (old hypervisors) are skipped.
+func TestHardwareAddCPUNilDetail(t *testing.T) {
+	t.Parallel()
+
+	var h Hardware
+
+	err := h.add(hwinfo.HardwareDevice{
+		Class:  hwinfo.HardwareClassCpu,
+		Detail: (*hwinfo.DetailCPU)(nil),
+	})
+	if err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	if len(h.CPU) != 0 {
+		t.Fatalf("expected no cpu entries, got %d", len(h.CPU))
+	}
+}


### PR DESCRIPTION
VMware can assign sparse physical ids to CPU sockets, e.g. 0, 2, 4 when a VM is configured with one core per socket. Indexing the CPU slice by physical id then leaves nil holes, which serialise as null entries in facter.json and breaks downstream nixpkgs modules.

Insert with append-or-replace keyed on physical id instead, so the list is always dense with one entry per socket.

Fixes #276