### PR TITLE
facter: tolerate duplicate smbios structures

### DIFF
--- a/pkg/facter/smbios.go
+++ b/pkg/facter/smbios.go
@@ -1,7 +1,6 @@
 package facter
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 
@@ -81,28 +80,30 @@ func (s *Smbios) add(item hwinfo.Smbios) error {
 
 	switch item.SmbiosType() {
 	case hwinfo.SmbiosTypeBios:
-		if s.Bios != nil {
-			return errors.New("bios field is already set")
-		} else if bios, ok := item.(*hwinfo.SmbiosBios); !ok {
+		if bios, ok := item.(*hwinfo.SmbiosBios); !ok {
 			return fmt.Errorf("expected hwinfo.SmbiosBios, found %T", item)
+		} else if s.Bios != nil {
+			// Malformed firmware tables (e.g. Apple EFI, #623) can yield duplicate
+			// singleton structures, so we keep the first and continue rather than abort the scan.
+			slog.Warn("duplicate smbios bios entry, keeping first", "handle", bios.Handle)
 		} else {
 			s.Bios = bios
 		}
 	case hwinfo.SmbiosTypeBoard:
-		if s.Board != nil {
-			return errors.New("board field is already set")
-		} else if board, ok := item.(*hwinfo.SmbiosBoard); !ok {
+		if board, ok := item.(*hwinfo.SmbiosBoard); !ok {
 			return fmt.Errorf("expected hwinfo.SmbiosBoard, found %T", item)
+		} else if s.Board != nil {
+			slog.Warn("duplicate smbios board entry, keeping first", "handle", board.Handle)
 		} else {
 			s.Board = board
 		}
 	case hwinfo.SmbiosTypeCache:
 		s.Cache = append(s.Cache, item)
 	case hwinfo.SmbiosTypeConfig:
-		if s.Config != nil {
-			return errors.New("config field is already set")
-		} else if config, ok := item.(*hwinfo.SmbiosConfig); !ok {
+		if config, ok := item.(*hwinfo.SmbiosConfig); !ok {
 			return fmt.Errorf("expected hwinfo.SmbiosConfig, found %T", item)
+		} else if s.Config != nil {
+			slog.Warn("duplicate smbios config entry, keeping first", "handle", config.Handle)
 		} else {
 			s.Config = config
 		}
@@ -139,10 +140,10 @@ func (s *Smbios) add(item hwinfo.Smbios) error {
 	case hwinfo.SmbiosTypeSlot:
 		s.Slot = append(s.Slot, item)
 	case hwinfo.SmbiosTypeSystem:
-		if s.System != nil {
-			return errors.New("system field is already set")
-		} else if system, ok := item.(*hwinfo.SmbiosSystem); !ok {
+		if system, ok := item.(*hwinfo.SmbiosSystem); !ok {
 			return fmt.Errorf("expected hwinfo.SmbiosSystem, found %T", item)
+		} else if s.System != nil {
+			slog.Warn("duplicate smbios system entry, keeping first", "handle", system.Handle)
 		} else {
 			s.System = system
 		}

--- a/pkg/facter/smbios_test.go
+++ b/pkg/facter/smbios_test.go
@@ -1,0 +1,57 @@
+//nolint:testpackage
+package facter
+
+import (
+	"testing"
+
+	"github.com/numtide/nixos-facter/pkg/hwinfo"
+)
+
+// Regression test for https://github.com/nix-community/nixos-facter/issues/623:
+// some firmware (e.g. Apple EFI on a 2014 Mac Mini) presents malformed SMBIOS
+// tables from which libhd decodes duplicate singleton structures. A duplicate
+// must not abort the scan; we keep the first entry and warn.
+func TestSmbiosAddDuplicateSingletons(t *testing.T) {
+	t.Parallel()
+
+	var s Smbios
+
+	first := &hwinfo.SmbiosBios{Type: hwinfo.SmbiosTypeBios, Handle: 0x0B, Vendor: "Apple Inc."}
+	second := &hwinfo.SmbiosBios{Type: hwinfo.SmbiosTypeBios, Handle: 0x0C, Vendor: "Phantom"}
+
+	if err := s.add(first); err != nil {
+		t.Fatalf("add first bios: %v", err)
+	}
+
+	if err := s.add(second); err != nil {
+		t.Fatalf("duplicate bios entry must not error: %v", err)
+	}
+
+	if s.Bios != first {
+		t.Fatalf("expected first bios entry to be kept, got %+v", s.Bios)
+	}
+
+	if err := s.add(&hwinfo.SmbiosSystem{Type: hwinfo.SmbiosTypeSystem}); err != nil {
+		t.Fatalf("add first system: %v", err)
+	}
+
+	if err := s.add(&hwinfo.SmbiosSystem{Type: hwinfo.SmbiosTypeSystem}); err != nil {
+		t.Fatalf("duplicate system entry must not error: %v", err)
+	}
+
+	if err := s.add(&hwinfo.SmbiosBoard{Type: hwinfo.SmbiosTypeBoard}); err != nil {
+		t.Fatalf("add first board: %v", err)
+	}
+
+	if err := s.add(&hwinfo.SmbiosBoard{Type: hwinfo.SmbiosTypeBoard}); err != nil {
+		t.Fatalf("duplicate board entry must not error: %v", err)
+	}
+
+	if err := s.add(&hwinfo.SmbiosConfig{Type: hwinfo.SmbiosTypeConfig}); err != nil {
+		t.Fatalf("add first config: %v", err)
+	}
+
+	if err := s.add(&hwinfo.SmbiosConfig{Type: hwinfo.SmbiosTypeConfig}); err != nil {
+		t.Fatalf("duplicate config entry must not error: %v", err)
+	}
+}


### PR DESCRIPTION
Malformed firmware tables can cause libhd to decode more than one type smbios structure. A late 2014 Mac Mini announces 2706 bytes of DMI data but only provides 2295, and the resulting parse yields a duplicate BIOS entry, aborting the whole scan with 'bios field is already set'.

A duplicate structure in out-of-spec vendor firmware is a nuisance, not a reason to produce no report at all. Keep the first entry, log a warning with the offending handle, and carry on.

Fixes #623