### PR TITLE
cloud: capture Hetzner instance metadata behind a cli flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,10 @@ func init() {
 	flag.StringVar(&outputPath, "o", "", "path to write the report")
 	flag.BoolVar(&scanner.Swap, "swap", false, "capture swap entries")
 	flag.BoolVar(
+		&scanner.Cloud.Hetzner, "cloud-hetzner", false,
+		"capture instance metadata from the Hetzner metadata service",
+	)
+	flag.BoolVar(
 		&scanner.Ephemeral, "ephemeral", false,
 		"capture all ephemeral properties e.g. swap, filesystems and so on",
 	)
@@ -75,6 +79,7 @@ Flags:
   -h, --help           help for nixos-facter
   -o, --output string  path to write the report
   --swap               capture swap entries
+  --cloud-hetzner      capture instance metadata from the Hetzner metadata service
   --version            version for nixos-facter
   --log-level string   log level, one of <error|warn|info|debug> (default "info")
   --hardware strings   Hardware items to probe.

--- a/docs/content/getting-started/generate-report.md
+++ b/docs/content/getting-started/generate-report.md
@@ -22,7 +22,7 @@ This will scan your system and produce a JSON-based report in a file named `fact
 
 ```json title="facter.json"
 {
-  "version": 2, // (1)!
+  "version": 1, // (1)!
   "system": "x86_64-linux", // (2)!
   "virtualisation": "none", // (3)!
   "hardware": { // (4)!
@@ -84,6 +84,32 @@ This will scan your system and produce a JSON-based report in a file named `fact
     ```
 
     See the [nixpkgs documentation](https://search.nixos.org/options?query=facter) for more details.
+
+## Cloud provider metadata
+
+### Hetzner
+
+When running on a [Hetzner](https://www.hetzner.com) instance, facter can capture instance metadata (e.g. the assigned IPv6 network
+configuration) from the Hetzner metadata service. It is disabled by default and must be enabled with a flag:
+
+```shell
+sudo nixos-facter --cloud-hetzner -o facter.json
+```
+
+The captured metadata is included in the report under a `cloud` section:
+
+```json title="facter.json"
+{
+  "cloud": {
+    "hetzner": {
+      "hostname": "my-server",
+      "instance-id": 123456,
+      "region": "eu-central",
+      ...
+    }
+  }
+}
+```
 
 [Nix]: https://nixos.org
 [Numtide]: https://numtide.com

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,14 @@ module github.com/numtide/nixos-facter
 
 go 1.26.4
 
-require github.com/stretchr/testify v1.11.1
+require (
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -1,0 +1,9 @@
+// Package cloud captures instance metadata from cloud providers for inclusion in the report.
+package cloud
+
+// Cloud groups metadata captured from cloud provider metadata services.
+type Cloud struct {
+	// Hetzner holds instance metadata fetched from the Hetzner metadata service,
+	// converted from its YAML representation.
+	Hetzner map[string]any `json:"hetzner,omitempty"`
+}

--- a/pkg/cloud/hetzner.go
+++ b/pkg/cloud/hetzner.go
@@ -1,0 +1,59 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// HetznerMetadataURL is the link-local endpoint of the Hetzner metadata service.
+// https://docs.hetzner.cloud/reference/cloud#description/server-metadata
+const HetznerMetadataURL = "http://169.254.169.254/hetzner/v1/metadata"
+
+// hetznerTimeout bounds the metadata request.
+// The service is link-local and should normally answer in milliseconds, but
+// we need to ensure we don't hang the scan when the flag is enabled on a
+// machine that isn't a Hetzner instance.
+const hetznerTimeout = 5 * time.Second
+
+// hetznerMaxResponseSize bounds the response body we are prepared to read.
+const hetznerMaxResponseSize = 1 << 20
+
+// HetznerMetadata fetches instance metadata from the given URL and converts
+// the YAML response into a JSON-serialisable map.
+func HetznerMetadata(ctx context.Context, url string) (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(ctx, hetznerTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch hetzner metadata: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch hetzner metadata: unexpected status %s", resp.Status)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, hetznerMaxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read hetzner metadata response: %w", err)
+	}
+
+	var metadata map[string]any
+
+	if err = yaml.Unmarshal(body, &metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse hetzner metadata as yaml: %w", err)
+	}
+
+	return metadata, nil
+}

--- a/pkg/cloud/hetzner_test.go
+++ b/pkg/cloud/hetzner_test.go
@@ -1,0 +1,107 @@
+package cloud_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/numtide/nixos-facter/pkg/cloud"
+	"github.com/stretchr/testify/require"
+)
+
+// metadata document as served by http://169.254.169.254/hetzner/v1/metadata,
+// composed from the sample values used in hcloud-go's metadata client tests:
+// https://github.com/hetznercloud/hcloud-go/blob/main/hcloud/metadata/client_test.go
+const hetznerMetadataFixture = `availability-zone: fsn1-dc14
+hostname: my-server
+instance-id: 123456
+local-ipv4: ""
+public-ipv4: 127.0.0.1
+region: eu-central
+public-keys: []
+private-networks:
+    - ip: 10.0.0.2
+      alias_ips: [10.0.0.3, 10.0.0.4]
+      interface_num: 1
+      mac_address: 86:00:00:2a:7d:e0
+      network_id: 1234
+      network_name: nw-test1
+      network: 10.0.0.0/8
+      subnet: 10.0.0.0/24
+      gateway: 10.0.0.1
+    - ip: 192.168.0.2
+      alias_ips: []
+      interface_num: 2
+      mac_address: 86:00:00:2a:7d:e1
+      network_id: 4321
+      network_name: nw-test2
+      network: 192.168.0.0/16
+      subnet: 192.168.0.0/24
+      gateway: 192.168.0.1
+`
+
+func TestHetznerMetadata(t *testing.T) {
+	t.Parallel()
+
+	rq := require.New(t)
+
+	var requestedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		_, _ = w.Write([]byte(hetznerMetadataFixture))
+	}))
+	defer server.Close()
+
+	metadata, err := cloud.HetznerMetadata(t.Context(), server.URL+"/hetzner/v1/metadata")
+	rq.NoError(err)
+	rq.Equal("/hetzner/v1/metadata", requestedPath)
+
+	// scalar fields survive the yaml decode
+	rq.Equal(123456, metadata["instance-id"])
+	rq.Equal("my-server", metadata["hostname"])
+	rq.Equal("eu-central", metadata["region"])
+	rq.Equal("fsn1-dc14", metadata["availability-zone"])
+	rq.Equal("127.0.0.1", metadata["public-ipv4"])
+
+	// nested structures are decoded, not flattened
+	networks, ok := metadata["private-networks"].([]any)
+	rq.True(ok, "private-networks should decode to a list")
+	rq.Len(networks, 2)
+
+	first, ok := networks[0].(map[string]any)
+	rq.True(ok, "private network entries should decode to maps")
+	rq.Equal("86:00:00:2a:7d:e0", first["mac_address"])
+	rq.Equal("10.0.0.1", first["gateway"])
+
+	// the whole document must serialise cleanly to JSON for the report
+	data, err := json.Marshal(cloud.Cloud{Hetzner: metadata})
+	rq.NoError(err)
+	rq.Contains(string(data), `"mac_address":"86:00:00:2a:7d:e0"`)
+	rq.Contains(string(data), `"alias_ips":["10.0.0.3","10.0.0.4"]`)
+}
+
+func TestHetznerMetadataUnavailable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := cloud.HetznerMetadata(t.Context(), server.URL+"/hetzner/v1/metadata")
+	require.Error(t, err)
+}
+
+func TestHetznerMetadataInvalidYaml(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("\t not: valid: yaml"))
+	}))
+	defer server.Close()
+
+	_, err := cloud.HetznerMetadata(t.Context(), server.URL+"/hetzner/v1/metadata")
+	require.Error(t, err)
+}

--- a/pkg/facter/facter.go
+++ b/pkg/facter/facter.go
@@ -3,12 +3,14 @@
 package facter
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 
 	"github.com/numtide/nixos-facter/pkg/boot"
 	"github.com/numtide/nixos-facter/pkg/build"
+	"github.com/numtide/nixos-facter/pkg/cloud"
 	"github.com/numtide/nixos-facter/pkg/ephem"
 	"github.com/numtide/nixos-facter/pkg/hwinfo"
 	"github.com/numtide/nixos-facter/pkg/virt"
@@ -38,6 +40,10 @@ type Report struct {
 
 	// Swap contains a list of swap entries representing the system's swap devices or files and their respective details.
 	Swap []*ephem.SwapEntry `json:"swap,omitempty"`
+
+	// Cloud holds instance metadata captured from cloud provider metadata services.
+	// It is only populated when the corresponding provider capture is enabled.
+	Cloud *cloud.Cloud `json:"cloud,omitempty"`
 }
 
 // Scanner defines a type responsible for scanning and reporting system hardware information.
@@ -48,6 +54,11 @@ type Scanner struct {
 	// Ephemeral indicates whether the scanner should report ephemeral details,
 	// such as swap.
 	Ephemeral bool
+
+	Cloud struct {
+		// Hetzner indicates whether instance metadata should be fetched from the Hetzner metadata service.
+		Hetzner bool
+	}
 
 	// Features is a list of ProbeFeature types that should be scanned for.
 	Features []hwinfo.ProbeFeature
@@ -138,6 +149,17 @@ func (s *Scanner) Scan() (*Report, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to detect swap devices: %w", err)
 		}
+	}
+
+	if s.Cloud.Hetzner {
+		slog.Debug("fetching hetzner metadata")
+
+		metadata, err := cloud.HetznerMetadata(context.Background(), cloud.HetznerMetadataURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to capture hetzner provider metadata: %w", err)
+		}
+
+		report.Cloud = &cloud.Cloud{Hetzner: metadata}
 	}
 
 	slog.Debug("report complete")


### PR DESCRIPTION
Hetzner exposes instance metadata (public IPv4, IPv6 network config, region, private networks, ...) on a link-local endpoint. NixOS configurations could make use of this for a variety of use cases.

Add a `cloud` section to the report, intended to capture cloud provider specific metadata when available, with `cloud.hetzner` being the first entry. When enabled, the metadata endpoint is queried, and it's YAML payload converted into JSON.

To be clear, this functionality is entirely opt-in. If a user enables the probe on a non-Hetzner machine, the request will time out and an error returned.

Closes #373