### PR TITLE
udev: support pre-252 usb keys & check the running daemon's version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,3 +31,10 @@ linters:
             rules:
                 - name: "exported"
                   disabled: true
+
+    exclusions:
+        rules:
+            # repeated literals in tests are fixture data, not magic constants
+            - path: _test\.go
+              linters:
+                  - goconst

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"log/slog"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/numtide/nixos-facter/pkg/build"
@@ -95,19 +94,14 @@ func Execute() {
 		return
 	}
 
-	// check udev version
-	_, err := exec.LookPath("udevadm")
-	if err != nil {
-		slog.Warn("udevadm not found, skipping udev version check")
-	} else {
-		udevVersion, err := udev.Version()
-		if err != nil {
-			log.Fatalf("failed to get udev version: %v", err)
-		}
+	// Check the running systemd-udevd daemon (it populates /run/udev/data).
+	udevVersion, err := udev.Version()
 
-		if udevVersion < 252 {
-			log.Fatalf("udev version %d is too old, please upgrade to at least 252", udevVersion)
-		}
+	switch {
+	case err != nil:
+		slog.Warn("could not determine the running udev version", "error", err)
+	case udevVersion < 252:
+		slog.Warn("udev version is older than 252, some device metadata may be incomplete", "version", udevVersion)
 	}
 
 	// Check if the effective user id is 0 e.g. root

--- a/nix/packages/nixos-facter/package.nix
+++ b/nix/packages/nixos-facter/package.nix
@@ -3,7 +3,6 @@
   systemdMinimal,
   hwinfo,
   gcc,
-  makeWrapper,
   pkg-config,
   stdenv,
   buildGo126Module,
@@ -37,7 +36,6 @@ buildGo126Module (final: {
 
   nativeBuildInputs = [
     gcc
-    makeWrapper
     pkg-config
     versionCheckHook
   ];
@@ -51,16 +49,6 @@ buildGo126Module (final: {
   ];
 
   doInstallCheck = true;
-  postInstall =
-    let
-      binPath = lib.makeBinPath [
-        systemdMinimal
-      ];
-    in
-    ''
-      wrapProgram "$out/bin/nixos-facter" \
-          --prefix PATH : "${binPath}"
-    '';
 
   meta = with lib; {
     description = "nixos-facter: declarative nixos-generate-config";

--- a/pkg/udev/udev.go
+++ b/pkg/udev/udev.go
@@ -51,6 +51,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unsafe"
@@ -132,36 +133,48 @@ type Usb struct {
 	Driver       string
 }
 
+// usbEnv returns the value of the ID_USB_-prefixed key, falling back to the
+// unprefixed name. The prefixed variants were introduced in systemd 252
+// (which exports both); older udev daemons (Ubuntu 22.04 ships 249) write only
+// the unprefixed names to /run/udev/data.
+func usbEnv(env map[string]string, key string) string {
+	if v, ok := env["ID_USB_"+key]; ok {
+		return v
+	}
+
+	return env["ID_"+key]
+}
+
 func NewUdevUsb(env map[string]string) (*Usb, error) {
 	if bus := env["ID_BUS"]; bus != "usb" {
 		return nil, fmt.Errorf("invalid bus: %s", bus)
 	}
 
 	result := &Usb{
-		Model:        env["ID_USB_MODEL"],
-		Vendor:       env["ID_USB_VENDOR"],
+		Model:        usbEnv(env, "MODEL"),
+		Vendor:       usbEnv(env, "VENDOR"),
 		Serial:       env["ID_SERIAL"],
-		Type:         env["ID_USB_TYPE"],
+		Type:         usbEnv(env, "TYPE"),
 		Interfaces:   env["ID_USB_INTERFACES"],
 		InterfaceNum: env["ID_USB_INTERFACE_NUM"],
 		Driver:       env["ID_USB_DRIVER"],
 	}
 
-	modelID, err := strconv.ParseUint(env["ID_USB_MODEL_ID"], 16, 16)
+	modelID, err := strconv.ParseUint(usbEnv(env, "MODEL_ID"), 16, 16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse model id: %w", err)
 	}
 
 	result.ModelID = uint16(modelID)
 
-	vendorID, err := strconv.ParseUint(env["ID_USB_VENDOR_ID"], 16, 16)
+	vendorID, err := strconv.ParseUint(usbEnv(env, "VENDOR_ID"), 16, 16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse vendor id: %w", err)
 	}
 
 	result.VendorID = uint16(vendorID)
 
-	revision, err := strconv.ParseUint(env["ID_USB_REVISION"], 16, 16)
+	revision, err := strconv.ParseUint(usbEnv(env, "REVISION"), 16, 16)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse revision: %w", err)
 	}
@@ -307,25 +320,52 @@ func Read(sysPath string) (*Udev, error) {
 	return NewUdev(env)
 }
 
-// Version retrieves the systemd major version by executing the "udevadm --version" command and parsing its output.
-// It returns the parsed version as an uint64, or an error if the command execution or parsing fails.
+// Version retrieves the major version of the running systemd-udevd daemon.
+// It asks systemd for the daemon's main PID (assuming systemctl is on PATH)
+// and executes the daemon's own binary with --version, so the result reflects
+// the running daemon rather than whatever udevadm happens to be installed.
 func Version() (uint64, error) {
-	cmd := exec.CommandContext(context.Background(), "udevadm", "--version")
-
-	output, err := cmd.Output()
+	out, err := exec.CommandContext(
+		context.Background(),
+		"systemctl", "show", "--property=MainPID", "--value", "systemd-udevd.service",
+	).Output()
 	if err != nil {
-		return 0, fmt.Errorf("failed to run udevadm --version: %w", err)
+		return 0, fmt.Errorf("failed to query systemd-udevd.service via systemctl: %w", err)
 	}
 
-	lines := strings.Split(string(output), "\n")
-	if len(lines) == 0 {
-		return 0, fmt.Errorf("unexpected empty output from udevadm --version: %s", output)
-	}
+	pidStr := strings.TrimSpace(string(out))
 
-	version, err := strconv.ParseUint(lines[0], 10, 16)
+	pid, err := strconv.ParseUint(pidStr, 10, 32)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse systemd version from udevadm --version: %w", err)
+		return 0, fmt.Errorf("failed to parse systemd-udevd MainPID from %q: %w", pidStr, err)
 	}
 
-	return version, nil
+	if pid == 0 {
+		return 0, errors.New("systemd-udevd.service is not running")
+	}
+
+	exe := filepath.Join("/proc", strconv.FormatUint(pid, 10), "exe")
+
+	output, err := exec.CommandContext(context.Background(), exe, "--version").Output()
+	if err != nil {
+		return 0, fmt.Errorf("failed to run %s --version: %w", exe, err)
+	}
+
+	return ParseVersion(string(output))
+}
+
+// ParseVersion extracts the numeric udev version from --version output.
+// udevadm prints a bare number (e.g. "260"); systemd-udevd prints
+// "systemd 249 (249.11-0ubuntu3)", so take the first numeric field of the
+// first line.
+func ParseVersion(output string) (uint64, error) {
+	line, _, _ := strings.Cut(output, "\n")
+
+	for field := range strings.FieldsSeq(line) {
+		if version, err := strconv.ParseUint(field, 10, 16); err == nil {
+			return version, nil
+		}
+	}
+
+	return 0, fmt.Errorf("failed to parse udev version from %q", line)
 }

--- a/pkg/udev/udev_test.go
+++ b/pkg/udev/udev_test.go
@@ -14,13 +14,95 @@ import (
 func TestNewUdevAcpiBus(t *testing.T) {
 	t.Parallel()
 
+	rq := require.New(t)
+
 	result, err := udev.NewUdev(map[string]string{
 		"ID_BUS":       "acpi",
 		"ID_INPUT":     "1",
 		"ID_INPUT_KEY": "1",
 	})
-	require.NoError(t, err, "NewUdev must accept ID_BUS=acpi without error")
-	require.NotNil(t, result)
-	require.NotNil(t, result.Input)
-	require.True(t, result.Input.IsKey)
+	rq.NoError(err, "NewUdev must accept ID_BUS=acpi without error")
+	rq.NotNil(result)
+	rq.NotNil(result.Input)
+	rq.True(result.Input.IsKey)
+}
+
+// TestNewUdevUsbOldKeyNames reproduces issue #202: udev < 252 exports only the
+// unprefixed ID_MODEL_ID / ID_VENDOR_ID / ID_REVISION keys (the ID_USB_*
+// variants arrived in systemd 252), which previously aborted the whole scan.
+// The env below is the reporter's verbatim /run/udev/data/+input:input4 from
+// udev 249 (Razer keyboard).
+func TestNewUdevUsbOldKeyNames(t *testing.T) {
+	t.Parallel()
+
+	rq := require.New(t)
+
+	result, err := udev.NewUdevUsb(map[string]string{
+		"ID_INPUT":             "1",
+		"ID_INPUT_MOUSE":       "1",
+		"ID_VENDOR":            "Razer",
+		"ID_VENDOR_ENC":        "Razer",
+		"ID_VENDOR_ID":         "1532",
+		"ID_MODEL":             "DeathStalker_Ultimate",
+		"ID_MODEL_ENC":         `DeathStalker\x20Ultimate`,
+		"ID_MODEL_ID":          "0114",
+		"ID_REVISION":          "0100",
+		"ID_SERIAL":            "Razer_DeathStalker_Ultimate",
+		"ID_TYPE":              "hid",
+		"ID_BUS":               "usb",
+		"ID_USB_INTERFACES":    ":030102:000000:030001:030101:fff000:",
+		"ID_USB_INTERFACE_NUM": "00",
+		"ID_USB_DRIVER":        "usbhid",
+	})
+	rq.NoError(err, "udev 249 key names must not abort the scan")
+	rq.NotNil(result)
+	rq.Equal(uint16(0x1532), result.VendorID)
+	rq.Equal(uint16(0x0114), result.ModelID)
+	rq.Equal(uint16(0x0100), result.Revision)
+	rq.Equal("DeathStalker_Ultimate", result.Model)
+	rq.Equal("Razer", result.Vendor)
+	rq.Equal("hid", result.Type)
+}
+
+// New key names take precedence when both are present (systemd >= 252 exports both).
+func TestNewUdevUsbPrefixedKeyNames(t *testing.T) {
+	t.Parallel()
+
+	rq := require.New(t)
+
+	result, err := udev.NewUdevUsb(map[string]string{
+		"ID_BUS":           "usb",
+		"ID_USB_MODEL_ID":  "c52b",
+		"ID_USB_VENDOR_ID": "046d",
+		"ID_USB_REVISION":  "2411",
+		// stale values the parser must ignore when prefixed keys are present
+		"ID_MODEL_ID":   "ffff",
+		"ID_VENDOR_ID":  "ffff",
+		"ID_REVISION":   "ffff",
+		"ID_USB_MODEL":  "USB_Receiver",
+		"ID_USB_VENDOR": "Logitech",
+	})
+	rq.NoError(err)
+	rq.Equal(uint16(0xc52b), result.ModelID)
+	rq.Equal(uint16(0x046d), result.VendorID)
+	rq.Equal(uint16(0x2411), result.Revision)
+}
+
+func TestParseVersion(t *testing.T) {
+	t.Parallel()
+
+	rq := require.New(t)
+
+	// bare number, as udevadm and systemd-udevd print it
+	version, err := udev.ParseVersion("260\n")
+	rq.NoError(err)
+	rq.Equal(uint64(260), version)
+
+	// distro-decorated form
+	version, err = udev.ParseVersion("systemd 249 (249.11-0ubuntu3)\n+PAM +AUDIT\n")
+	rq.NoError(err)
+	rq.Equal(uint64(249), version)
+
+	_, err = udev.ParseVersion("no numbers here\n")
+	rq.Error(err)
 }


### PR DESCRIPTION
udev < 252 exports unprefixed `ID_MODEL_ID`, `ID_VENDOR_ID` and `ID_REVISION` keys for usb devices. Newer versions use an `ID_USB_` prefix, but also export the older variant (for now). Parse the `ID_USB_`-prefixed variants first, falling back to the unprefixed `ID_*` keys if necessary.

Udev version check now becomes an advisory, rather than a failure. We now check the version of the running udev daemon, rather than whichever `udevadm` we find on the PATH.

Fixes #202